### PR TITLE
[3.7.0-SNAPSHOT][fix] fixed error "parent_folder is required" + PEP8

### DIFF
--- a/cohort/models.py
+++ b/cohort/models.py
@@ -13,46 +13,36 @@ from django.db import models
 
 from admin_cohort.models import CohortBaseModel
 
-COHORT_TYPE_CHOICES = [
-    ("IMPORT_I2B2", "Previous cohorts imported from i2b2.",),
-    ("MY_ORGANIZATIONS", "Organizations in which I work (care sites "
-                         "with pseudo-anonymised reading rights).",),
-    ("MY_PATIENTS", "Patients that passed by all my organizations "
-                    "(care sites with nominative reading rights)."),
-    ("MY_COHORTS", "Cohorts I created in Cohort360")
-]
+COHORT_TYPE_CHOICES = [("IMPORT_I2B2", "Previous cohorts imported from i2b2.",),
+                       ("MY_ORGANIZATIONS", "Organizations in which I work (care sites "
+                                            "with pseudo-anonymised reading rights).",),
+                       ("MY_PATIENTS", "Patients that passed by all my organizations "
+                                       "(care sites with nominative reading rights)."),
+                       ("MY_COHORTS", "Cohorts I created in Cohort360")]
 
 I2B2_COHORT_TYPE = COHORT_TYPE_CHOICES[0][0]
 MY_ORGANISATIONS_COHORT_TYPE = COHORT_TYPE_CHOICES[1][0]
 MY_PATIENTS_COHORT_TYPE = COHORT_TYPE_CHOICES[2][0]
 MY_COHORTS_COHORT_TYPE = COHORT_TYPE_CHOICES[3][0]
 
-REQUEST_DATA_TYPE_CHOICES = [
-    ("PATIENT", 'FHIR Patient'),
-    ('ENCOUNTER', 'FHIR Encounter')
-]
+REQUEST_DATA_TYPE_CHOICES = [('PATIENT', 'FHIR Patient'),
+                             ('ENCOUNTER', 'FHIR Encounter')]
 PATIENT_REQUEST_TYPE = REQUEST_DATA_TYPE_CHOICES[0][0]
 
 SNAPSHOT_DM_MODE = "Snapshot"
 GLOBAL_DM_MODE = "Global"
-DATED_MEASURE_MODE_CHOICES = [
-    (SNAPSHOT_DM_MODE, SNAPSHOT_DM_MODE),
-    (GLOBAL_DM_MODE, GLOBAL_DM_MODE)
-]
+DATED_MEASURE_MODE_CHOICES = [(SNAPSHOT_DM_MODE, SNAPSHOT_DM_MODE),
+                              (GLOBAL_DM_MODE, GLOBAL_DM_MODE)]
 
 
 class Folder(CohortBaseModel):
-    owner = models.ForeignKey(
-        User, on_delete=models.CASCADE, related_name='folders',
-    )
+    owner = models.ForeignKey(User, on_delete=models.CASCADE, related_name='folders')
     name = models.CharField(max_length=50)
-    parent_folder = models.ForeignKey(
-        "cohort.Folder", on_delete=models.CASCADE,
-        related_name="children_folders", null=True
-    )
+    parent_folder = models.ForeignKey("cohort.Folder", on_delete=models.CASCADE, related_name="children_folders",
+                                      null=True)
 
     class Meta:
-        unique_together = ('owner', 'name', 'parent_folder')
+        unique_together = ('owner', 'name')
 
     def __str__(self):
         return f"{self.name} ({self.owner})"
@@ -62,31 +52,17 @@ class Folder(CohortBaseModel):
 
 
 class Request(CohortBaseModel):
-    owner = models.ForeignKey(
-        User, on_delete=models.CASCADE, related_name='user_requests',
-    )
-
+    owner = models.ForeignKey(User, on_delete=models.CASCADE, related_name='user_requests')
     name = models.CharField(max_length=255)
     description = models.TextField(blank=True)
     favorite = models.BooleanField(default=False)
-
-    parent_folder = models.ForeignKey(
-        Folder, on_delete=models.CASCADE, related_name="requests", null=False
-    )
-
-    data_type_of_query = models.CharField(
-        max_length=9, choices=REQUEST_DATA_TYPE_CHOICES,
-        default=PATIENT_REQUEST_TYPE
-    )
-
-    shared_by = models.ForeignKey(
-        User, on_delete=models.SET_NULL,
-        related_name='shared_requests', null=True, default=None,
-    )
+    parent_folder = models.ForeignKey(Folder, on_delete=models.CASCADE, related_name="requests", null=False)
+    data_type_of_query = models.CharField(max_length=9, choices=REQUEST_DATA_TYPE_CHOICES, default=PATIENT_REQUEST_TYPE)
+    shared_by = models.ForeignKey(User, on_delete=models.SET_NULL, related_name='shared_requests', null=True,
+                                  default=None)
 
     def last_request_snapshot(self):
-        return RequestQuerySnapshot.objects.filter(request__uuid=self.uuid) \
-            .latest('created_at')
+        return RequestQuerySnapshot.objects.filter(request__uuid=self.uuid).latest('created_at')
 
     def saved_snapshot(self):
         return self.query_snapshots.filter(saved=True).first()
@@ -94,36 +70,24 @@ class Request(CohortBaseModel):
     @property
     def dated_measures(self):
         return reduce(lambda a, b: a | b,
-                      [rqs.dated_measures.all()
-                       for rqs in self.query_snapshots.all()],
+                      [rqs.dated_measures.all() for rqs in self.query_snapshots.all()],
                       DatedMeasure.objects.none())
 
 
 class RequestQuerySnapshot(CohortBaseModel):
-    owner = models.ForeignKey(
-        User, on_delete=models.CASCADE,
-        related_name='user_request_query_snapshots',
-    )
-    request = models.ForeignKey(
-        Request, on_delete=models.CASCADE, related_name='query_snapshots'
-    )
-
+    owner = models.ForeignKey(User, on_delete=models.CASCADE, related_name='user_request_query_snapshots')
+    request = models.ForeignKey(Request, on_delete=models.CASCADE, related_name='query_snapshots')
     serialized_query = models.TextField(default="{}")
-    previous_snapshot = models.ForeignKey(
-        "RequestQuerySnapshot", related_name="next_snapshots",
-        on_delete=models.SET_NULL, null=True)
+    previous_snapshot = models.ForeignKey("RequestQuerySnapshot", related_name="next_snapshots",
+                                          on_delete=models.SET_NULL, null=True)
     is_active_branch = models.BooleanField(default=True)
-    shared_by = models.ForeignKey(
-        User, on_delete=models.SET_NULL,
-        related_name='shared_query_snapshots', null=True, default=None,
-    )
-
+    shared_by = models.ForeignKey(User, on_delete=models.SET_NULL, related_name='shared_query_snapshots',
+                                  null=True, default=None)
     # unused, untested
     saved = models.BooleanField(default=False)
     refresh_every_seconds = models.BigIntegerField(default=0)
     refresh_create_cohort = models.BooleanField(default=False)
-    perimeters_ids = ArrayField(models.CharField(max_length=15),
-                                null=True, blank=True)
+    perimeters_ids = ArrayField(models.CharField(max_length=15), null=True, blank=True)
 
     @property
     def active_next_snapshot(self):
@@ -133,58 +97,42 @@ class RequestQuerySnapshot(CohortBaseModel):
 
     def share(self, recipients: List[User], name: str) -> RequestQuerySnapshot:
         dct_recipients = dict([(r.pk, r) for r in recipients])
-        folders = list(Folder.objects.filter(
-            owner__in=recipients, name=SHARED_FOLDER_NAME, parent_folder=None)
-        )
+        folders = list(Folder.objects.filter(owner__in=recipients, name=SHARED_FOLDER_NAME, parent_folder=None))
         owners_ids = [folder.owner.pk for folder in folders]
-        folders_to_create = [
-            Folder(owner=r, name=SHARED_FOLDER_NAME, parent_folder=None)
-            for r in recipients if r.pk not in owners_ids
-        ]
-        dct_folders = dict([(f.owner.pk, f)
-                            for f in folders + folders_to_create])
+        folders_to_create = [Folder(owner=r, name=SHARED_FOLDER_NAME, parent_folder=None)
+                             for r in recipients if r.pk not in owners_ids]
+        dct_folders = dict([(f.owner.pk, f) for f in folders + folders_to_create])
         request_name = name or self.request.name
 
-        requests = [
-            Request(
-                **{
-                    **dict([
-                        (f.name, getattr(self.request, f.name))
-                        for f in Request._meta.fields
-                        if f.name != Request._meta.pk.name
-                    ]),
-                    'owner': dct_recipients[o], 'favorite': False,
-                    'name': request_name,
-                    'shared_by': self.owner,
-                    'parent_folder': f
-                }
-            )
-            for (o, f) in dct_folders.items()]
+        requests = [Request(**{**dict([(field.name, getattr(self.request, field.name))
+                                       for field in Request._meta.fields if field.name != Request._meta.pk.name]),
+                               'owner': dct_recipients[o],
+                               'favorite': False,
+                               'name': request_name,
+                               'shared_by': self.owner,
+                               'parent_folder': f
+                               })
+                    for (o, f) in dct_folders.items()]
 
-        dct_requests = dict([(r.owner.pk, r)
-                             for r in requests])
+        dct_requests = dict([(r.owner.pk, r) for r in requests])
 
-        rqss = [
-            RequestQuerySnapshot(**{
-                **dict([
-                    (f.name, getattr(self, f.name))
-                    for f in RequestQuerySnapshot._meta.fields
-                    if f.name != RequestQuerySnapshot._meta.pk.name
-                ]),
-                'shared_by': self.owner,
-                'owner': dct_recipients[o],
-                'previous_snapshot': None,
-                'is_active_branch': True,
-                'saved': False,
-                'refresh_every_seconds': 0,
-                'refresh_create_cohort': False,
-                'request': r})
-            for (o, r) in dct_requests.items()]
+        rqss = [RequestQuerySnapshot(**{**dict([(field.name, getattr(self, field.name))
+                                                for field in RequestQuerySnapshot._meta.fields
+                                                if field.name != RequestQuerySnapshot._meta.pk.name]),
+                                        'shared_by': self.owner,
+                                        'owner': dct_recipients[o],
+                                        'previous_snapshot': None,
+                                        'is_active_branch': True,
+                                        'saved': False,
+                                        'refresh_every_seconds': 0,
+                                        'refresh_create_cohort': False,
+                                        'request': r
+                                        })
+                for (o, r) in dct_requests.items()]
 
         Folder.objects.bulk_create(folders_to_create)
         Request.objects.bulk_create(requests)
         created = RequestQuerySnapshot.objects.bulk_create(rqss)
-
         return created
 
     def save(self, *args, **kwargs):
@@ -199,7 +147,6 @@ class RequestQuerySnapshot(CohortBaseModel):
         if previous_saved is not None:
             previous_saved.saved = False
             previous_saved.save()
-
         self.saved = True
         self.save()
 
@@ -210,15 +157,9 @@ class DatedMeasure(CohortBaseModel, JobModel):
     possibly generating a Cohort/Group in Fhir.
     """
     # todo : fix this, user_request_query_results is wrong
-    owner = models.ForeignKey(
-        User, on_delete=models.CASCADE,
-        related_name='user_request_query_results',
-    )
-    request_query_snapshot = models.ForeignKey(
-        RequestQuerySnapshot, on_delete=models.CASCADE,
-        related_name='dated_measures'
-    )
-
+    owner = models.ForeignKey(User, on_delete=models.CASCADE, related_name='user_request_query_results')
+    request_query_snapshot = models.ForeignKey(RequestQuerySnapshot, on_delete=models.CASCADE,
+                                               related_name='dated_measures')
     fhir_datetime = models.DateTimeField(null=True, blank=False)
     # Size of potential cohort as returned by SolR
     measure = models.BigIntegerField(null=True, blank=False)
@@ -229,47 +170,27 @@ class DatedMeasure(CohortBaseModel, JobModel):
     measure_deceased = models.BigIntegerField(null=True, blank=True)
     measure_alive = models.BigIntegerField(null=True, blank=True)
     measure_female = models.BigIntegerField(null=True, blank=True)
-
     count_task_id = models.TextField(blank=True)
-
-    mode = models.CharField(
-        max_length=20, choices=DATED_MEASURE_MODE_CHOICES,
-        default=SNAPSHOT_DM_MODE, null=True
-    )
+    mode = models.CharField(max_length=20, choices=DATED_MEASURE_MODE_CHOICES, default=SNAPSHOT_DM_MODE, null=True)
 
 
 class CohortResult(CohortBaseModel, JobModel):
-    owner = models.ForeignKey(
-        User, on_delete=models.CASCADE, related_name='user_cohorts',
-    )
-
+    owner = models.ForeignKey(User, on_delete=models.CASCADE, related_name='user_cohorts')
     name = models.CharField(max_length=255, blank=True, null=True)
     description = models.TextField(blank=True, null=True)
     favorite = models.BooleanField(default=False)
-
-    request_query_snapshot = models.ForeignKey(
-        RequestQuerySnapshot, on_delete=models.CASCADE,
-        related_name='cohort_results'
-    )
-
+    request_query_snapshot = models.ForeignKey(RequestQuerySnapshot, on_delete=models.CASCADE,
+                                               related_name='cohort_results')
     fhir_group_id = models.CharField(max_length=64, blank=True)
-    dated_measure = models.ForeignKey(
-        DatedMeasure, related_name="cohort", on_delete=models.CASCADE
-    )
-    dated_measure_global = models.ForeignKey(
-        DatedMeasure, related_name="restricted_cohort", null=True,
-        on_delete=models.SET_NULL
-    )
-
+    dated_measure = models.ForeignKey(DatedMeasure, related_name="cohort", on_delete=models.CASCADE)
+    dated_measure_global = models.ForeignKey(DatedMeasure, related_name="restricted_cohort", null=True,
+                                             on_delete=models.SET_NULL)
     create_task_id = models.TextField(blank=True)
 
     # will depend on the right (pseudo-anonymised or nominative) you
     # have on the care_site
     # unused untested
-    type = models.CharField(
-        max_length=20, choices=COHORT_TYPE_CHOICES,
-        default=MY_COHORTS_COHORT_TYPE
-    )
+    type = models.CharField(max_length=20, choices=COHORT_TYPE_CHOICES, default=MY_COHORTS_COHORT_TYPE)
 
     @property
     def result_size(self):


### PR DESCRIPTION
 when creating a folder, an error is raised stating that "_parent_folder is required_" which is not. Caused by a misdefined uniqueness constraint on the Folder model: removed **parent_folder** field from _unique_together_ definition