### PR TITLE
[3.7.0-SNAPSHOT] PEP8

### DIFF
--- a/cohort/conf_cohort_job_api.py
+++ b/cohort/conf_cohort_job_api.py
@@ -147,7 +147,7 @@ class JobResponse:
             self.result: List[JobResult] = [init_result_from_response_dict(resp, jr) for jr in job_result]
         else:
             self.result: List[JobResult] = [init_result_from_response_dict(resp, job_result)]
-        if not self.result and self.status in [JobStatus.finished.name, JobStatus.failed.name]:
+        if not self.result and self.status in [JobStatus.finished.value, JobStatus.failed.value]:
             raise Exception(f"FHIR ERROR: Result is empty - {resp.text}")
 
         self.request_response: Response = resp
@@ -311,7 +311,7 @@ def post_count_cohort(json_file: str, auth_headers, log_prefix: str = "", dated_
         return FhirCountResponse(job_duration=datetime.now() - d, success=False, fhir_job_status=JobStatus.failed,
                                  err_msg=err_msg)
 
-    dated_measure.request_job_status = job.status.name.lower()
+    dated_measure.request_job_status = job.status.value
     dated_measure.request_job_id = job.job_id
     dated_measure.save()
 
@@ -445,10 +445,10 @@ def post_create_cohort(json_file: str, auth_headers, log_prefix: str = "", cohor
 
     print(f"{log_prefix} Step 3: Job created. Waiting for it to be finished")
 
-    cohort_result.request_job_status = job.status.name.lower()
+    cohort_result.request_job_status = job.status.value
     cohort_result.request_job_id = job.job_id
     cohort_result.save()
-    cohort_result.dated_measure.request_job_status = job.status.name.lower()
+    cohort_result.dated_measure.request_job_status = job.status.value
     cohort_result.dated_measure.request_job_id = job.job_id
     cohort_result.dated_measure.save()
 

--- a/cohort/tasks.py
+++ b/cohort/tasks.py
@@ -116,7 +116,7 @@ def get_count_task(auth_headers: dict, json_file: str, dm_uuid: str):
             dm.measure_max = resp.count_max
 
         dm.fhir_datetime = resp.fhir_datetime
-        dm.request_job_status = resp.fhir_job_status.name.lower()
+        dm.request_job_status = resp.fhir_job_status.value
         dm.request_job_duration = resp.job_duration
         dm.request_job_id = resp.fhir_job_id
         dm.save()

--- a/cohort/tests.py
+++ b/cohort/tests.py
@@ -34,7 +34,7 @@ RQS_URL = f"{EXPLORATIONS_URL}/request-query-snapshots"
 DATED_MEASURES_URL = f"{EXPLORATIONS_URL}/dated-measures"
 COHORTS_URL = f"{EXPLORATIONS_URL}/cohorts"
 
-REQUEST_STATUS_CHOICES = [(e.name.lower(), e.name.lower()) for e in JobStatus]
+REQUEST_STATUS_CHOICES = [(e.name, e.value) for e in JobStatus]
 
 
 # TODO : test for post save0 get saved, get last_modified,
@@ -1451,7 +1451,7 @@ class DatedMeasuresDeleteTests(DatedMeasuresTests):
             created_at=timezone.now(),
             modified_at=timezone.now(),
             request_job_id="test",
-            request_job_status=JobStatus.pending.name,
+            request_job_status=JobStatus.pending.value,
             request_job_fail_msg="test",
             request_job_duration="1s",
         )
@@ -1506,7 +1506,7 @@ class DatedMeasuresUpdateTests(DatedMeasuresTests):
             created_at=timezone.now(),
             modified_at=timezone.now(),
             request_job_id="test",
-            request_job_status=JobStatus.pending.name,
+            request_job_status=JobStatus.pending.value,
             request_job_fail_msg="test",
             request_job_duration="1s",
         )
@@ -1942,7 +1942,7 @@ class CohortsDeleteTests(CohortsTests):
             created_at=timezone.now(),
             modified_at=timezone.now(),
             request_job_id="test",
-            request_job_status=JobStatus.pending.name,
+            request_job_status=JobStatus.pending.value,
             request_job_fail_msg="test",
             request_job_duration="1s",
         )
@@ -1983,7 +1983,7 @@ class CohortsUpdateTests(CohortsTests):
             created_at=timezone.now(),
             modified_at=timezone.now(),
             request_job_id="test",
-            request_job_status=JobStatus.pending.name,
+            request_job_status=JobStatus.pending.value,
             request_job_fail_msg="test",
             request_job_duration="1s",
         )

--- a/cohort/views.py
+++ b/cohort/views.py
@@ -235,7 +235,7 @@ class DatedMeasureViewSet(NestedViewSetMixin, UserObjectsRestrictedViewSet):
                             status.HTTP_400_BAD_REQUEST)
 
         req_dms = rqs.request.dated_measures
-        started_status = JobStatus.started.name.lower()
+        started_status = JobStatus.started.value
         started_jobs_to_cancel = req_dms.filter(request_job_status=started_status).prefetch_related('cohort',
                                                                                                     'restricted_cohort')
         for job in started_jobs_to_cancel:
@@ -251,7 +251,7 @@ class DatedMeasureViewSet(NestedViewSetMixin, UserObjectsRestrictedViewSet):
                                             f"bound to dated-measure '{job.uuid}': {str(e)}"},
                                 status.HTTP_500_INTERNAL_SERVER_ERROR)
 
-        pending_status = JobStatus.pending.name.lower()
+        pending_status = JobStatus.pending.value
         pending_jobs_to_cancel = req_dms.filter(request_job_status=pending_status).prefetch_related('cohort',
                                                                                                     'restricted_cohort')
         for job in pending_jobs_to_cancel:


### PR DESCRIPTION
this PR includes minor changes to the use of JobStatus enum. Checkings were made by comparing enum's members names casted to lower case to some string status value. Use members values instead.