### PR TITLE
[Hotfix 3.9.2] allow log files even in DEBUG envs

### DIFF
--- a/.conf/gunicorn.conf.py
+++ b/.conf/gunicorn.conf.py
@@ -21,8 +21,7 @@ logconfig_dict = dict(
             "handlers": ["access_file"],
             "propagate": True,
             "qualname": "gunicorn.access"
-        }
-    },
+        }},
     handlers={
         "console": {
             "class": "logging.StreamHandler",
@@ -31,19 +30,18 @@ logconfig_dict = dict(
         },
         "access_file": {
             "class": "logging.handlers.RotatingFileHandler",
-            "filename": "/app/log/gunicorn.access.log",
+            "filename": "log/gunicorn.access.log",
             "maxBytes": 100 * 1024 * 1024,
-            "backupCount": 100_000,
-            "formatter": "generic",
+            "backupCount": 1000,
+            "formatter": "generic"
         },
         "error_file": {
             "class": "logging.handlers.RotatingFileHandler",
-            "filename": "/app/log/gunicorn.error.log",
+            "filename": "log/gunicorn.error.log",
             "maxBytes": 100 * 1024 * 1024,
-            "backupCount": 100_000,
-            "formatter": "generic",
-        },
-    },
+            "backupCount": 1000,
+            "formatter": "generic"
+        }},
     formatters={
         "generic": {
             "format": "%(asctime)s [%(process)d] [%(levelname)s] %(message)s",

--- a/.gitignore
+++ b/.gitignore
@@ -115,4 +115,7 @@ GitHub.sublime-settings
 !.vscode/launch.json 
 !.vscode/extensions.json 
 .history
+
 /accesses/migrations/0023_caresite_concept_provider.py
+
+log

--- a/README.md
+++ b/README.md
@@ -114,9 +114,12 @@ python3.11 --version
    \q
    ```
 4. Configuration : 
-- create a **.env** file (admin_cohort/.env) following **admin_cohort/.env.example** format
+- Create a **.env** file (admin_cohort/.env) following **admin_cohort/.env.example** format
 
-5. Django migrations files are already included per application. Next, run migrations to create the database tables
+5. Logs
+- Create a directory **log** in the project directory to store log files.
+
+6. Django migrations files are already included per application. Next, run migrations to create the database tables
    ```sh
    source venv/bin/activate
    python manage.py migrate

--- a/accesses/serializers.py
+++ b/accesses/serializers.py
@@ -19,7 +19,7 @@ from .conf_perimeters import Provider
 from .models import Role, Access, Profile, Perimeter
 from .permissions import can_user_manage_access
 
-_log = logging.getLogger('error')
+_log = logging.getLogger('django.request')
 
 
 def check_date_rules(

--- a/admin_cohort/__init__.py
+++ b/admin_cohort/__init__.py
@@ -1,5 +1,5 @@
 __title__ = 'Portail API'
-__version__ = '3.9.1'
+__version__ = '3.9.2'
 __author__ = 'Assistance Publique - Hopitaux de Paris, Département I&D'
 
 

--- a/admin_cohort/backends.py
+++ b/admin_cohort/backends.py
@@ -4,7 +4,7 @@ from admin_cohort import conf_auth
 from admin_cohort.conf_auth import LoginError, ServerError, JwtTokens
 from admin_cohort.models import User, get_or_create_user_with_info
 
-_log = logging.getLogger('error')
+_log = logging.getLogger('django.request')
 
 
 def get_or_create_user(jwt_access_token: str) -> User:

--- a/admin_cohort/settings.py
+++ b/admin_cohort/settings.py
@@ -62,13 +62,13 @@ LOGGING = dict(version=1,
                loggers={
                    'info': {
                        'level': "INFO",
-                       'handlers': ["console"],
+                       'handlers': ['console', 'info_handler'],
                        'propagate': True
                    },
-                   'error': {
+                   'django.request': {
                        'level': "ERROR",
-                       'handlers': ["console", "mail_admins"],
-                       'propagate': True
+                       'handlers': ['console', 'error_handler', 'mail_admins'],
+                       'propagate': False,
                    }},
                handlers={
                    'console': {
@@ -77,6 +77,22 @@ LOGGING = dict(version=1,
                        'stream': "ext://sys.stdout",
                        'formatter': "verbose"
                    },
+                   'info_handler': {
+                       'level': "INFO",
+                       'class': "logging.handlers.RotatingFileHandler",
+                       'filename': "log/django.log",
+                       'maxBytes': 100 * 1024 * 1024,
+                       'backupCount': 1000,
+                       'formatter': "verbose"
+                    },
+                   'error_handler': {
+                       'level': "ERROR",
+                       'class': "logging.handlers.RotatingFileHandler",
+                       'filename': "log/django.error.log",
+                       'maxBytes': 100 * 1024 * 1024,
+                       'backupCount': 1000,
+                       'formatter': "verbose"
+                    },
                    'mail_admins': {
                        'level': "ERROR",
                        'class': "django.utils.log.AdminEmailHandler",
@@ -88,23 +104,6 @@ LOGGING = dict(version=1,
                        'style': "{"
                    }
                })
-if not DEBUG:
-    LOGGING["loggers"]["info"]["handlers"] = ["info_handler"]
-    LOGGING["loggers"]["error"]["handlers"] = ["error_handler", "mail_admins"]
-
-    info_handler = {'level': "INFO",
-                    'class': "logging.handlers.RotatingFileHandler",
-                    'filename': "/app/log/django.log",
-                    'maxBytes': 100 * 1024 * 1024,
-                    "backupCount": 100_000,
-                    'formatter': "verbose"
-                    }
-    error_handler = info_handler.copy()
-    error_handler.update({'level': "ERROR",
-                          'filename': "/app/log/django.error.log"
-                          })
-    LOGGING["handlers"].update({"info_handler": info_handler,
-                                "error_handler": error_handler})
 
 
 # Application definition

--- a/cohort/views.py
+++ b/cohort/views.py
@@ -27,7 +27,7 @@ from cohort.serializers import RequestSerializer, CohortResultSerializer, Reques
     DatedMeasureSerializer, FolderSerializer, CohortResultSerializerFullDatedMeasure, CohortRightsSerializer
 from cohort.tools import get_all_cohorts_rights, get_dict_cohort_pop_source
 
-_log = logging.getLogger('error')
+_log = logging.getLogger('django.request')
 
 
 class NoUpdateViewSetMixin:

--- a/exports/emails.py
+++ b/exports/emails.py
@@ -31,7 +31,7 @@ KEY_DELETE_DATE = "KEY_DELETE_DATE"
 KEY_DATABASE_NAME = "KEY_DATABASE_NAME"
 
 
-_log = logging.getLogger('error')
+_log = logging.getLogger('django.request')
 
 
 def send_mail(msg: EmailMultiAlternatives):

--- a/exports/tasks.py
+++ b/exports/tasks.py
@@ -15,7 +15,7 @@ from .models import ExportRequest
 from .types import ExportType, HdfsServerUnreachableError, ApiJobResponse
 
 _log_info = logging.getLogger('info')
-_log_err = logging.getLogger('error')
+_log_err = logging.getLogger('django.request')
 
 
 def log_export_request_task(er_id, msg):

--- a/exports/views/export_request.py
+++ b/exports/views/export_request.py
@@ -26,7 +26,7 @@ from exports.serializers import ExportRequestSerializer, ExportRequestSerializer
 from exports.tasks import launch_request
 from exports.types import ExportType
 
-_log = logging.getLogger('error')
+_log = logging.getLogger('django.request')
 
 
 class ExportRequestFilter(filters.FilterSet):


### PR DESCRIPTION
Log separation done in this issue Ref https://gitlab.eds.aphp.fr/dev/cohort360/gestion-de-projet/-/issues/1733 was done in a way that does not allow to create log files for Django in environments where debug mode is enabled.
This behavior is changed and log files are present in all env.
For local development, a **log** directory must be present in your project tree (and is .gitignored) to contain log files.