### PR TITLE
fix: retrieve accesses per perimeter

### DIFF
--- a/accesses/views/access.py
+++ b/accesses/views/access.py
@@ -20,20 +20,12 @@ from admin_cohort.settings import PERIMETERS_TYPES, ACCESS_EXPIRY_FIRST_ALERT_IN
 from admin_cohort.tools import join_qs
 from admin_cohort.views import BaseViewset, CustomLoggingMixin
 from admin_cohort.cache_utils import flush_cache
-from ..models import Role, Access, get_user_valid_manual_accesses_queryset, intersect_queryset_criteria, build_data_rights, Profile
+from ..models import Access, get_user_valid_manual_accesses_queryset, intersect_queryset_criteria, build_data_rights, Profile
 from ..permissions import AccessPermissions
 from ..serializers import AccessSerializer, DataRightSerializer, ExpiringAccessesSerializer
 
 
 class AccessFilter(filters.FilterSet):
-    def target_perimeter_filter(self, queryset, field, value):
-        if value:
-            return queryset.filter((join_qs([Q(**{'perimeter' + i * '__children': value})
-                                             for i in range(1, len(PERIMETERS_TYPES))])
-                                    & Role.impact_lower_levels_query('role'))
-                                   | Q(perimeter=value))
-        return queryset
-
     provider_email = filters.CharFilter(lookup_expr="icontains", field_name="profile__email")
     provider_lastname = filters.CharFilter(lookup_expr="icontains", field_name="profile__lastname")
     provider_firstname = filters.CharFilter(lookup_expr="icontains", field_name="profile__firstname")
@@ -49,9 +41,6 @@ class AccessFilter(filters.FilterSet):
 
     perimeter_name = filters.CharFilter(field_name="perimeter__name", lookup_expr="icontains")
     care_site_id = filters.CharFilter(field_name="perimeter_id")
-
-    target_care_site_id = filters.CharFilter(method="target_perimeter_filter")
-    target_perimeter_id = filters.CharFilter(method="target_perimeter_filter")
 
     ordering = OrderingFilter(fields=(('role__name', 'role_name'),
                                       ('sql_start_datetime', 'start_datetime'),


### PR DESCRIPTION
This PR is about changing the logic behind retrieving accesses configured on a given perimeter.
 - no longer get nested accesses, only those directly attached to the given perimeter (do not include accesses on child perimeters)
 - deleted unused filters
 