### PR TITLE
ci: clarify publish workflow run names

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,8 @@
-name: cohort360-backend-publish
+name: Publish Docker backend
+
+run-name: >-
+  Publish Docker backend - ${{ github.event.workflow_run.head_branch }}
+  - ${{ github.event.workflow_run.display_title }}
 
 on:
   workflow_run:
@@ -11,6 +15,7 @@ on:
 
 jobs:
   publish:
+    name: Build and push backend Docker image - ${{ github.event.workflow_run.head_branch }}
     runs-on: ubuntu-latest
     if: github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push'
 


### PR DESCRIPTION
## Résumé
- Renomme le workflow de publish Docker backend avec un libellé humain.
- Ajoute un `run-name` basé sur la branche et le titre du run amont.
- Rend le nom du job Docker plus explicite dans les détails du run.

## Validation
- `npx --yes yaml-lint .github/workflows/publish.yml`
- `git diff --check`

Note: `actionlint` n'était pas disponible localement, et `go` non plus pour le lancer via `go run`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow naming and display information for improved pipeline visibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/aphp/Cohort360-Back-end/pull/522)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->