### PR TITLE
feat(accesses): add right_read_logs to grant logs consultation

### DIFF
--- a/accesses/data/new_rights.py
+++ b/accesses/data/new_rights.py
@@ -103,6 +103,12 @@ rights = [
         "category": "Datalabs",
         "is_global": True,
     },
+    {
+        "name": "right_read_logs",
+        "label": "Consulter les logs",
+        "category": "Logs",
+        "is_global": True,
+    },
 ]
 
 dependent_rights = [

--- a/accesses/migrations/0022_role_right_read_logs.py
+++ b/accesses/migrations/0022_role_right_read_logs.py
@@ -1,0 +1,15 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("accesses", "0021_remove_role_right_read_practitioner_data"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="role",
+            name="right_read_logs",
+            field=models.BooleanField(default=False),
+        ),
+    ]

--- a/accesses/models/role.py
+++ b/accesses/models/role.py
@@ -33,6 +33,7 @@ class Role(BaseModel):
     right_search_patients_by_ipp = models.BooleanField(default=False, null=False)
     right_search_patients_unlimited = models.BooleanField(default=False, null=False)
     right_search_opposed_patients = models.BooleanField(default=False, null=False)
+    right_read_logs = models.BooleanField(default=False, null=False)
 
     class Meta:
         constraints = [UniqueConstraint(name="unique_name", fields=["name"], condition=Q(delete_datetime__isnull=True))]
@@ -71,6 +72,7 @@ class Role(BaseModel):
             or self.right_search_patients_unlimited
             or self.right_manage_admin_accesses_same_level
             or self.right_manage_admin_accesses_inferior_levels
+            or self.right_read_logs
         )
 
     def requires_admin_accesses_managing_right_to_be_managed(self):

--- a/accesses/services/accesses.py
+++ b/accesses/services/accesses.py
@@ -36,6 +36,11 @@ class AccessesService:
     def user_is_full_admin(self, user: User) -> bool:
         return any(access.role is not None and access.role.right_full_admin for access in self.get_user_valid_accesses(user))
 
+    def user_can_read_logs(self, user: User) -> bool:
+        return any(
+            access.role is not None and (access.role.right_full_admin or access.role.right_read_logs) for access in self.get_user_valid_accesses(user)
+        )
+
     @staticmethod
     def get_expiring_accesses(user: User, accesses: QuerySet):
         today = date.today()

--- a/admin_cohort/permissions.py
+++ b/admin_cohort/permissions.py
@@ -24,7 +24,7 @@ class MaintenancesPermission(IsAuthenticated):
 class LogsPermission(IsAuthenticated):
     def has_permission(self, request, view):
         authenticated = super().has_permission(request, view)
-        return authenticated and accesses_service.user_is_full_admin(request.user)
+        return authenticated and accesses_service.user_can_read_logs(request.user)
 
     def has_object_permission(self, request, view, obj):
         return self.has_permission(request=request, view=view)

--- a/admin_cohort/tests/test_request_log.py
+++ b/admin_cohort/tests/test_request_log.py
@@ -57,3 +57,35 @@ class RequestLogTests(BaseTests):
         response = RequestLogViewSet.as_view({"get": "list"})(request)
         response.render()
         self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
+
+    def test_list_request_logs_with_only_right_read_logs(self):
+        user, profile = new_user_and_profile()
+        role = Role.objects.create(name="LogsReader", right_read_logs=True)
+        Access.objects.create(
+            perimeter=self.aphp,
+            role=role,
+            profile=profile,
+            start_datetime=timezone.now(),
+            end_datetime=timezone.now() + timedelta(days=365),
+        )
+        request = self.factory.get(REQUEST_LOGS_URL)
+        force_authenticate(request, user)
+        response = RequestLogViewSet.as_view({"get": "list"})(request)
+        response.render()
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
+
+    def test_list_request_logs_without_right_is_forbidden(self):
+        user, profile = new_user_and_profile()
+        role = Role.objects.create(name="NoRights")
+        Access.objects.create(
+            perimeter=self.aphp,
+            role=role,
+            profile=profile,
+            start_datetime=timezone.now(),
+            end_datetime=timezone.now() + timedelta(days=365),
+        )
+        request = self.factory.get(REQUEST_LOGS_URL)
+        force_authenticate(request, user)
+        response = RequestLogViewSet.as_view({"get": "list"})(request)
+        response.render()
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN, response.content)


### PR DESCRIPTION
## Objectif
Fixes https://gitlab.data.aphp.fr/ID/design-et-produit/ipa/cohort360/gestion-de-projet/-/work_items/3182

Ajoute le droit `right_read_logs` pour permettre aux utilisateurs de consulter les logs sans nécessiter `right_full_admin`.

## Changements réalisés
- `Role` : ajout du champ `right_read_logs` + migration 0022.
- `AccessesService.user_can_read_logs()` : true si l'utilisateur a `right_full_admin` ou `right_read_logs` sur un access valide.
- `LogsPermission` bascule sur le nouveau service.
- L'octroi du droit est restreint via `requires_full_admin_right_to_be_managed()` : seul un full_admin peut l'attribuer.
- Entrée correspondante dans `accesses/data/new_rights.py` (catégorie "Logs", global).

## Impacts
Droits / sécurité : nouveau droit global, octroi réservé à full_admin. Aucun changement d'API publique. Le front portail doit publier la PR liée pour exposer le toggle.

## Tests réalisés
Tests ajoutés dans `admin_cohort/tests/test_request_log.py` : user avec `right_read_logs` seul → 200 ; user sans droit → 403. Tests existants inchangés.

## Risques
La migration ajoute un champ booléen `default=False` → aucune row existante impactée. Pas de filtrage par périmètre : un user avec le droit voit tous les logs (cf. ticket — étape ultérieure éventuelle).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new "Read Logs" permission to enable users to view application logs. Users can now be granted log access independently without requiring full administrator privileges, providing more granular permission control.

* **Tests**
  * Added tests to verify log access permissions are correctly enforced for both authorized and unauthorized users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->