### PR TITLE
fix(snapshot): dedup concurrent/duplicate RQS creations

### DIFF
--- a/cohort/services/request_query_snapshot.py
+++ b/cohort/services/request_query_snapshot.py
@@ -14,12 +14,14 @@ logger = logging.getLogger(__name__)
 
 class RequestQuerySnapshotService:
     @staticmethod
-    def process_creation_data(data: dict) -> None:
+    def process_creation_data(data: dict) -> Optional[RequestQuerySnapshot]:
         previous_snapshot_id = data.get("previous_snapshot")
         request_id = data.get("request")
+        previous_snapshot: Optional[RequestQuerySnapshot] = None
         if previous_snapshot_id:
             previous_snapshot = RequestQuerySnapshot.objects.get(pk=previous_snapshot_id)
-            if request_id and request_id != previous_snapshot.request_id:
+            # cast both: request_id may be a str (JSON body) while .request_id is UUID
+            if request_id and str(request_id) != str(previous_snapshot.request_id):
                 raise ValueError("The provided request is different from the previous_snapshot's request")
             data["request"] = previous_snapshot.request_id
         elif request_id:
@@ -36,8 +38,14 @@ class RequestQuerySnapshotService:
         req_id = data.get("request")
         if req_id is None:
             raise ValueError("request is required")
-        request = Request.objects.get(pk=req_id)
+
+        request = Request.objects.select_for_update().get(pk=req_id)
+
+        if previous_snapshot is not None and previous_snapshot.serialized_query == serialized_query:
+            return previous_snapshot
+
         data["version"] = request.query_snapshots.count() + 1
+        return None
 
     @staticmethod
     def check_shared_folders(recipients: List[User]) -> tuple[List[Folder], dict[str, Folder]]:

--- a/cohort/tests/tests_view_rqs.py
+++ b/cohort/tests/tests_view_rqs.py
@@ -309,6 +309,57 @@ class RqsCreateTests(RqsTests):
             )
         )
 
+    def _make_previous_with_test_query(self) -> RequestQuerySnapshot:
+        return RequestQuerySnapshot.objects.create(
+            owner=self.user1,
+            request=self.user1_req2,
+            serialized_query=self.test_query,
+        )
+
+    def test_idempotent_create_returns_previous_when_same_serialized_query(self):
+        # As a user, if I POST a snapshot whose serialized_query equals its
+        # previous_snapshot's serialized_query, the back must not create a
+        # duplicate row: it returns the previous snapshot with status 200.
+        # This absorbs the duplicated-POST case from the front.
+        previous = self._make_previous_with_test_query()
+        request_pre_count = previous.request.query_snapshots.count()
+
+        data = {
+            "owner": self.user1.pk,
+            "request": previous.request.pk,
+            "previous_snapshot": previous.pk,
+            "serialized_query": previous.serialized_query,
+        }
+        request = self.factory.post(self.objects_url, data=data, format="json")
+        force_authenticate(request, self.user1)
+        response = self.__class__.create_view(request)
+        response.render()
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK, msg=response.content)
+        self.assertEqual(response.data["uuid"], str(previous.pk))
+        self.assertEqual(previous.request.query_snapshots.count(), request_pre_count)
+
+    def test_create_with_different_serialized_query_still_creates(self):
+        # Sanity check: idempotency must not block a legitimate edit on top of
+        # the same previous_snapshot.
+        previous = self._make_previous_with_test_query()
+        request_pre_count = previous.request.query_snapshots.count()
+
+        edited_query = '{"test": "edited", "sourcePopulation": {"caresiteCohortList": ["1", "2", "3"]}}'
+        data = {
+            "owner": self.user1.pk,
+            "request": previous.request.pk,
+            "previous_snapshot": previous.pk,
+            "serialized_query": edited_query,
+        }
+        request = self.factory.post(self.objects_url, data=data, format="json")
+        force_authenticate(request, self.user1)
+        response = self.__class__.create_view(request)
+        response.render()
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED, msg=response.content)
+        self.assertEqual(previous.request.query_snapshots.count(), request_pre_count + 1)
+
     # def test_error_create_unvalid_query(self):
     #     # As a user, I cannot create a RQS if the query server deny the query
     #     # or the query is not a json

--- a/cohort/views/request_query_snapshot.py
+++ b/cohort/views/request_query_snapshot.py
@@ -1,3 +1,4 @@
+from django.db import transaction
 from django.http import QueryDict
 from drf_spectacular.utils import extend_schema, extend_schema_view
 from rest_framework import status
@@ -22,13 +23,19 @@ class RequestQuerySnapshotViewSet(NestedViewSetMixin, UserObjectsRestrictedViewS
     swagger_tags = ["Request Query Snapshots"]
     filterset_fields = ["request", "name", "shared_by", "previous_snapshot", "request", "request__parent_folder"]
 
-    @extend_schema(request=RQSCreateSerializer, responses={status.HTTP_201_CREATED: RQSSerializer})
+    @extend_schema(
+        request=RQSCreateSerializer,
+        responses={status.HTTP_200_OK: RQSSerializer, status.HTTP_201_CREATED: RQSSerializer},
+    )
     def create(self, request, *args, **kwargs):
         try:
-            rqs_service.process_creation_data(data=request.data)
+            with transaction.atomic():
+                existing = rqs_service.process_creation_data(data=request.data)
+                if existing is not None:
+                    return Response(RQSSerializer(existing).data, status=status.HTTP_200_OK)
+                return super().create(request, *args, **kwargs)
         except ValueError as ve:
             return Response(data=f"{ve}", status=status.HTTP_400_BAD_REQUEST)
-        return super().create(request, *args, **kwargs)
 
     @extend_schema(request=RQSShareSerializer, responses={status.HTTP_201_CREATED: None})
     @action(detail=True, methods=["post"], url_path="share")


### PR DESCRIPTION
## Objectif

Quand le front envoie deux POST quasi-simultanés pour créer une snapshot (cas reproductible via l'éditeur JSON, cf. 1239 côté FrontEnd), le back insère deux lignes `RequestQuerySnapshot` avec le même numéro de `version` — d'où les séquences "1, 1, 3" au lieu de "1, 2, 3".

Fixes [gestion-de-projet#3259](https://gitlab.data.aphp.fr/ID/design-et-produit/ipa/cohort360/gestion-de-projet/-/work_items/3259) (partie Backend).

## Cause

`RequestQuerySnapshotService.process_creation_data` calculait `version = request.query_snapshots.count() + 1` sans lock ni transaction, donc deux requêtes concurrentes lisent le même `count()` et insèrent le même `version`. Aucune contrainte DB ne bloquait le doublon.

## Changements réalisés

- **Lock + atomic** : `transaction.atomic` autour de la création dans la vue, avec `select_for_update` sur le `Request` parent dans le service. Les créations concurrentes sont sérialisées.
- **Idempotence par contenu** : si le `serialized_query` reçu est identique à celui du `previous_snapshot`, le service retourne la snapshot existante et la vue répond `200 OK` avec sa représentation au lieu d'insérer un doublon.
- **Tests** : deux cas ajoutés dans `RqsCreateTests` — idempotence (POST identique → 200, aucune ligne créée) et sanity check qu'une vraie édition crée toujours bien la nouvelle version (201).

## Impacts

Backend uniquement. Aucune migration. Le front continue de fonctionner sans modification — il reçoit soit `201` avec une nouvelle snapshot, soit `200` avec celle qui existe déjà.

## Tests réalisés

- Tests unitaires ajoutés dans `cohort/tests/tests_view_rqs.py`
- Smoke-import Django OK localement
- Suite complète à valider en CI

## Risques

- Faible. Le lock est court (le temps de la création), la sérialisation des POST sur un même `Request` est ce qu'on veut.
- Le changement de statut `201` → `200` pour le cas idempotent est conforme HTTP mais à signaler si un client attendait strictement `201`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Request query snapshot creation endpoints now exhibit idempotent behavior—resubmitting identical query parameters returns the existing snapshot with HTTP 200 rather than creating a duplicate.

* **Tests**
  * Added test coverage for idempotent snapshot creation and HTTP status code validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->