### PR TITLE
feat(health): add FHIR connectivity check with Redis cache

### DIFF
--- a/admin_cohort/services/health.py
+++ b/admin_cohort/services/health.py
@@ -23,7 +23,7 @@ FHIR_CACHE_TTL_SECONDS = 300
 _HTTP_HARD_FAIL_CODES = {status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN}
 
 
-def _http_reachable(url: str, *, method: str = "GET", **kwargs) -> None:
+def _http_reachable(url: str, *, method: str = "GET", **kwargs) -> requests.Response:
     """Perform an HTTP call and treat any 5xx, 401, 403 or transport error as a failure.
 
     4xx (other than auth) is considered "service is up and recognised our request shape".
@@ -31,6 +31,7 @@ def _http_reachable(url: str, *, method: str = "GET", **kwargs) -> None:
     response = requests.request(method=method, url=url, timeout=CHECK_TIMEOUT_SECONDS, **kwargs)
     if response.status_code >= status.HTTP_500_INTERNAL_SERVER_ERROR or response.status_code in _HTTP_HARD_FAIL_CODES:
         raise RuntimeError(f"HTTP {response.status_code}")
+    return response
 
 
 def _check_django() -> None:
@@ -163,10 +164,13 @@ def _check_fhir() -> Optional[str]:
             return None
         raise RuntimeError(cached.get("error") or "cached failure")
     try:
-        _http_reachable(
+        response = _http_reachable(
             f"{fhir_url.rstrip('/')}/metadata",
             headers={"Accept": "application/fhir+json"},
         )
+        resource_type = response.json().get("resourceType")
+        if resource_type != "CapabilityStatement":
+            raise RuntimeError(f"unexpected resourceType: {resource_type!r}")
     except Exception as exc:
         cache.set(FHIR_CACHE_KEY, {"ok": False, "error": str(exc)[:300]}, FHIR_CACHE_TTL_SECONDS)
         raise

--- a/admin_cohort/services/health.py
+++ b/admin_cohort/services/health.py
@@ -162,14 +162,10 @@ def _check_fhir() -> Optional[str]:
         if cached.get("ok"):
             return None
         raise RuntimeError(cached.get("error") or "cached failure")
-    from admin_cohort.services.auth import jwt_auth_service
-
-    token = jwt_auth_service.generate_system_token()
     try:
         _http_reachable(
-            f"{fhir_url.rstrip('/')}/Patient",
-            params={"active": "true", "_count": "0"},
-            headers={"Authorization": f"Bearer {token}", "Accept": "application/fhir+json"},
+            f"{fhir_url.rstrip('/')}/metadata",
+            headers={"Accept": "application/fhir+json"},
         )
     except Exception as exc:
         cache.set(FHIR_CACHE_KEY, {"ok": False, "error": str(exc)[:300]}, FHIR_CACHE_TTL_SECONDS)

--- a/admin_cohort/services/health.py
+++ b/admin_cohort/services/health.py
@@ -7,6 +7,7 @@ from typing import Callable, Optional
 import requests
 from django.apps import apps
 from django.conf import settings
+from django.core.cache import cache
 from django.db import connections
 from rest_framework import status
 
@@ -15,6 +16,9 @@ _logger = logging.getLogger(__name__)
 
 CHECK_TIMEOUT_SECONDS = 2.0
 GLOBAL_TIMEOUT_SECONDS = CHECK_TIMEOUT_SECONDS + 1.0
+
+FHIR_CACHE_KEY = "health:fhir"
+FHIR_CACHE_TTL_SECONDS = 300
 
 _HTTP_HARD_FAIL_CODES = {status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN}
 
@@ -149,6 +153,31 @@ def _check_influxdb() -> Optional[str]:
     return None
 
 
+def _check_fhir() -> Optional[str]:
+    fhir_url = os.environ.get("FHIR_URL")
+    if not fhir_url:
+        return "skipped"
+    cached = cache.get(FHIR_CACHE_KEY)
+    if cached is not None:
+        if cached.get("ok"):
+            return None
+        raise RuntimeError(cached.get("error") or "cached failure")
+    from admin_cohort.services.auth import jwt_auth_service
+
+    token = jwt_auth_service.generate_system_token()
+    try:
+        _http_reachable(
+            f"{fhir_url.rstrip('/')}/Patient",
+            params={"active": "true", "_count": "0"},
+            headers={"Authorization": f"Bearer {token}", "Accept": "application/fhir+json"},
+        )
+    except Exception as exc:
+        cache.set(FHIR_CACHE_KEY, {"ok": False, "error": str(exc)[:300]}, FHIR_CACHE_TTL_SECONDS)
+        raise
+    cache.set(FHIR_CACHE_KEY, {"ok": True, "error": None}, FHIR_CACHE_TTL_SECONDS)
+    return None
+
+
 CHECKS: list[tuple[str, Callable[[], Optional[str]], bool]] = [
     ("django", _check_django, True),
     ("db_default", _check_db_default, True),
@@ -160,6 +189,7 @@ CHECKS: list[tuple[str, Callable[[], Optional[str]], bool]] = [
     ("export_api", _check_export_api, False),
     ("smtp", _check_smtp, False),
     ("influxdb", _check_influxdb, False),
+    ("fhir", _check_fhir, False),
 ]
 
 

--- a/admin_cohort/tests/test_health.py
+++ b/admin_cohort/tests/test_health.py
@@ -9,9 +9,12 @@ from rest_framework.test import APIClient
 
 from admin_cohort.services import health as health_module
 from admin_cohort.services.health import (
+    FHIR_CACHE_KEY,
+    FHIR_CACHE_TTL_SECONDS,
     _check_db_default,
     _check_django,
     _check_export_api,
+    _check_fhir,
     _check_hadoop_api,
     _check_identity_server,
     _check_influxdb,
@@ -184,6 +187,60 @@ class IndividualChecksTests(SimpleTestCase):
         with self.assertRaises(RuntimeError):
             _check_influxdb()
         client.close.assert_called_once()
+
+
+class CheckFhirTests(SimpleTestCase):
+    def test_skipped_when_no_url(self):
+        with patch.dict("os.environ", {"FHIR_URL": ""}):
+            self.assertEqual(_check_fhir(), "skipped")
+
+    @patch("admin_cohort.services.health._http_reachable")
+    @patch("admin_cohort.services.health.cache")
+    def test_cache_hit_ok_skips_http_call(self, mock_cache, mock_http):
+        mock_cache.get.return_value = {"ok": True, "error": None}
+        with patch.dict("os.environ", {"FHIR_URL": "http://fhir/"}):
+            self.assertIsNone(_check_fhir())
+        mock_http.assert_not_called()
+        mock_cache.set.assert_not_called()
+
+    @patch("admin_cohort.services.health._http_reachable")
+    @patch("admin_cohort.services.health.cache")
+    def test_cache_hit_ko_raises_without_http_call(self, mock_cache, mock_http):
+        mock_cache.get.return_value = {"ok": False, "error": "previous boom"}
+        with patch.dict("os.environ", {"FHIR_URL": "http://fhir/"}):
+            with self.assertRaises(RuntimeError) as ctx:
+                _check_fhir()
+        self.assertIn("previous boom", str(ctx.exception))
+        mock_http.assert_not_called()
+        mock_cache.set.assert_not_called()
+
+    @patch("admin_cohort.services.auth.jwt_auth_service.generate_system_token", return_value="sys-token")
+    @patch("admin_cohort.services.health._http_reachable")
+    @patch("admin_cohort.services.health.cache")
+    def test_cache_miss_success_caches_ok(self, mock_cache, mock_http, _mock_token):
+        mock_cache.get.return_value = None
+        with patch.dict("os.environ", {"FHIR_URL": "http://fhir/"}):
+            self.assertIsNone(_check_fhir())
+        mock_http.assert_called_once_with(
+            "http://fhir/Patient",
+            params={"active": "true", "_count": "0"},
+            headers={"Authorization": "Bearer sys-token", "Accept": "application/fhir+json"},
+        )
+        mock_cache.set.assert_called_once_with(
+            FHIR_CACHE_KEY, {"ok": True, "error": None}, FHIR_CACHE_TTL_SECONDS
+        )
+
+    @patch("admin_cohort.services.auth.jwt_auth_service.generate_system_token", return_value="sys-token")
+    @patch("admin_cohort.services.health._http_reachable", side_effect=RuntimeError("HTTP 500"))
+    @patch("admin_cohort.services.health.cache")
+    def test_cache_miss_failure_caches_ko_and_raises(self, mock_cache, _mock_http, _mock_token):
+        mock_cache.get.return_value = None
+        with patch.dict("os.environ", {"FHIR_URL": "http://fhir/"}):
+            with self.assertRaises(RuntimeError):
+                _check_fhir()
+        mock_cache.set.assert_called_once_with(
+            FHIR_CACHE_KEY, {"ok": False, "error": "HTTP 500"}, FHIR_CACHE_TTL_SECONDS
+        )
 
 
 class RunCheckTests(SimpleTestCase):

--- a/admin_cohort/tests/test_health.py
+++ b/admin_cohort/tests/test_health.py
@@ -226,9 +226,7 @@ class CheckFhirTests(SimpleTestCase):
             params={"active": "true", "_count": "0"},
             headers={"Authorization": "Bearer sys-token", "Accept": "application/fhir+json"},
         )
-        mock_cache.set.assert_called_once_with(
-            FHIR_CACHE_KEY, {"ok": True, "error": None}, FHIR_CACHE_TTL_SECONDS
-        )
+        mock_cache.set.assert_called_once_with(FHIR_CACHE_KEY, {"ok": True, "error": None}, FHIR_CACHE_TTL_SECONDS)
 
     @patch("admin_cohort.services.auth.jwt_auth_service.generate_system_token", return_value="sys-token")
     @patch("admin_cohort.services.health._http_reachable", side_effect=RuntimeError("HTTP 500"))
@@ -238,9 +236,7 @@ class CheckFhirTests(SimpleTestCase):
         with patch.dict("os.environ", {"FHIR_URL": "http://fhir/"}):
             with self.assertRaises(RuntimeError):
                 _check_fhir()
-        mock_cache.set.assert_called_once_with(
-            FHIR_CACHE_KEY, {"ok": False, "error": "HTTP 500"}, FHIR_CACHE_TTL_SECONDS
-        )
+        mock_cache.set.assert_called_once_with(FHIR_CACHE_KEY, {"ok": False, "error": "HTTP 500"}, FHIR_CACHE_TTL_SECONDS)
 
 
 class RunCheckTests(SimpleTestCase):

--- a/admin_cohort/tests/test_health.py
+++ b/admin_cohort/tests/test_health.py
@@ -214,24 +214,21 @@ class CheckFhirTests(SimpleTestCase):
         mock_http.assert_not_called()
         mock_cache.set.assert_not_called()
 
-    @patch("admin_cohort.services.auth.jwt_auth_service.generate_system_token", return_value="sys-token")
     @patch("admin_cohort.services.health._http_reachable")
     @patch("admin_cohort.services.health.cache")
-    def test_cache_miss_success_caches_ok(self, mock_cache, mock_http, _mock_token):
+    def test_cache_miss_success_caches_ok(self, mock_cache, mock_http):
         mock_cache.get.return_value = None
         with patch.dict("os.environ", {"FHIR_URL": "http://fhir/"}):
             self.assertIsNone(_check_fhir())
         mock_http.assert_called_once_with(
-            "http://fhir/Patient",
-            params={"active": "true", "_count": "0"},
-            headers={"Authorization": "Bearer sys-token", "Accept": "application/fhir+json"},
+            "http://fhir/metadata",
+            headers={"Accept": "application/fhir+json"},
         )
         mock_cache.set.assert_called_once_with(FHIR_CACHE_KEY, {"ok": True, "error": None}, FHIR_CACHE_TTL_SECONDS)
 
-    @patch("admin_cohort.services.auth.jwt_auth_service.generate_system_token", return_value="sys-token")
     @patch("admin_cohort.services.health._http_reachable", side_effect=RuntimeError("HTTP 500"))
     @patch("admin_cohort.services.health.cache")
-    def test_cache_miss_failure_caches_ko_and_raises(self, mock_cache, _mock_http, _mock_token):
+    def test_cache_miss_failure_caches_ko_and_raises(self, mock_cache, _mock_http):
         mock_cache.get.return_value = None
         with patch.dict("os.environ", {"FHIR_URL": "http://fhir/"}):
             with self.assertRaises(RuntimeError):

--- a/admin_cohort/tests/test_health.py
+++ b/admin_cohort/tests/test_health.py
@@ -218,6 +218,7 @@ class CheckFhirTests(SimpleTestCase):
     @patch("admin_cohort.services.health.cache")
     def test_cache_miss_success_caches_ok(self, mock_cache, mock_http):
         mock_cache.get.return_value = None
+        mock_http.return_value.json.return_value = {"resourceType": "CapabilityStatement"}
         with patch.dict("os.environ", {"FHIR_URL": "http://fhir/"}):
             self.assertIsNone(_check_fhir())
         mock_http.assert_called_once_with(
@@ -234,6 +235,20 @@ class CheckFhirTests(SimpleTestCase):
             with self.assertRaises(RuntimeError):
                 _check_fhir()
         mock_cache.set.assert_called_once_with(FHIR_CACHE_KEY, {"ok": False, "error": "HTTP 500"}, FHIR_CACHE_TTL_SECONDS)
+
+    @patch("admin_cohort.services.health._http_reachable")
+    @patch("admin_cohort.services.health.cache")
+    def test_cache_miss_wrong_resource_type_caches_ko_and_raises(self, mock_cache, mock_http):
+        mock_cache.get.return_value = None
+        mock_http.return_value.json.return_value = {"resourceType": "OperationOutcome"}
+        with patch.dict("os.environ", {"FHIR_URL": "http://fhir/"}):
+            with self.assertRaises(RuntimeError) as ctx:
+                _check_fhir()
+        self.assertIn("OperationOutcome", str(ctx.exception))
+        mock_cache.set.assert_called_once()
+        cached_payload = mock_cache.set.call_args.args[1]
+        self.assertFalse(cached_payload["ok"])
+        self.assertIn("OperationOutcome", cached_payload["error"])
 
 
 class RunCheckTests(SimpleTestCase):

--- a/admin_cohort/tests/test_health.py
+++ b/admin_cohort/tests/test_health.py
@@ -32,13 +32,15 @@ from admin_cohort.tools.exception_handler import custom_exception_handler
 class HttpReachableTests(unittest.TestCase):
     @patch("admin_cohort.services.health.requests.request")
     def test_2xx_ok(self, mock_request):
-        mock_request.return_value = MagicMock(status_code=200)
-        self.assertIsNone(_http_reachable("http://x"))
+        response = MagicMock(status_code=200)
+        mock_request.return_value = response
+        self.assertIs(_http_reachable("http://x"), response)
 
     @patch("admin_cohort.services.health.requests.request")
     def test_4xx_non_auth_is_ok(self, mock_request):
-        mock_request.return_value = MagicMock(status_code=404)
-        self.assertIsNone(_http_reachable("http://x"))
+        response = MagicMock(status_code=404)
+        mock_request.return_value = response
+        self.assertIs(_http_reachable("http://x"), response)
 
     @patch("admin_cohort.services.health.requests.request")
     def test_500_raises(self, mock_request):


### PR DESCRIPTION
## Objectif
Fixes https://gitlab.data.aphp.fr/ID/design-et-produit/ipa/cohort360/gestion-de-projet/-/work_items/3261

## Changements réalisés
Ajout d'un check `_check_fhir` dans `admin_cohort.services.health.CHECKS`. Appelle `GET {FHIR_URL}/metadata` (anonyme). Résultat caché en Redis (`health:fhir`, TTL 300 s), succès et erreurs. Non critique. Skip si `FHIR_URL` absent. Timeout aligné sur `CHECK_TIMEOUT_SECONDS = 2 s`.

## Impacts
Back. `/health` expose un sous-statut `fhir`. ~1 call FHIR / 5 min / cache partagé Redis. Pas de DB, pas de droits, pas de token.

## Tests réalisés
Tests unitaires `CheckFhirTests` : skip, cache hit ok, cache hit ko, cache miss success, cache miss failure. `ruff check` et `ruff format` ok. Suite Django à passer en CI.

## Risques
Une erreur reste cachée 5 min après réparation de FHIR. `/metadata` ne valide que la connectivité, pas l'auth.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added FHIR server health check that validates server connectivity and caches results to improve performance.

* **Tests**
  * Added test suite for FHIR health check to ensure proper validation and caching behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->