### PR TITLE
feat(monitoring): support prometheus multiprocess mode for gunicorn workers

### DIFF
--- a/.conf/gunicorn.conf.py
+++ b/.conf/gunicorn.conf.py
@@ -1,7 +1,9 @@
+import os
 from logging.handlers import DEFAULT_TCP_LOGGING_PORT
 
 from environ import environ
 from gunicorn.glogging import Logger
+from prometheus_client import multiprocess
 
 env = environ.Env()
 workers = 7
@@ -43,3 +45,8 @@ logconfig_dict = {
         },
     },
 }
+
+
+def child_exit(server, worker):
+    if os.environ.get("PROMETHEUS_MULTIPROC_DIR"):
+        multiprocess.mark_process_dead(worker.pid)


### PR DESCRIPTION
## Objectif

Fix le bug observé en qualif : les Counter/Histogram `cohort360_*` restent à 0 alors que la gauge `cohort360_jobs_in_progress` (custom Collector + query DB) marche.

Cause : gunicorn lance 7 workers (cf `.conf/gunicorn.conf.py`) + celery worker dans le même pod (cf `docker-entrypoint.sh`). Chaque process a son propre registry Prometheus en mémoire ; le scrape `/metrics` tape un worker à la fois → incréments invisibles.

Related to https://gitlab.data.aphp.fr/ID/design-et-produit/ipa/cohort360/gestion-de-projet/-/work_items/3287

## Changements

`.conf/gunicorn.conf.py` : ajout du hook `child_exit` qui appelle `multiprocess.mark_process_dead(worker.pid)` quand un worker meurt, gated par la présence de l'env var `PROMETHEUS_MULTIPROC_DIR` (pas de régression en dev local).

Le mode multi-process est activé automatiquement par `prometheus_client` quand la var est posée. Aucun autre changement applicatif requis : Counter, Histogram et le Custom Collector `JobsInProgressCollector` continuent de fonctionner, désormais agrégés cross-process.

## Dépendance

Cette PR doit être déployée avec une MR ops qui pose `PROMETHEUS_MULTIPROC_DIR` + un emptyDir tmpfs partagé entre gunicorn et celery. Tant que la var n'est pas définie, ce hook est no-op.

## Tests

- `ruff check` + `ruff format --check` OK
- `deptry` OK (`prometheus-client` déjà déclaré explicitement)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced monitoring infrastructure for multi-process deployments, improving worker lifecycle tracking and ensuring accurate metric collection across distributed instances. This strengthens application observability and system stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->