### PR TITLE
fix(monitoring): expose jobs_in_progress collector in multiprocess mode

### DIFF
--- a/admin_cohort/tests/test_metrics.py
+++ b/admin_cohort/tests/test_metrics.py
@@ -1,0 +1,37 @@
+import os
+import tempfile
+from unittest.mock import patch
+
+from django.test import TestCase
+from django.urls import reverse
+from rest_framework import status
+
+
+class MetricsViewTests(TestCase):
+    databases = {"default"}
+
+    def setUp(self):
+        self.url = reverse("metrics")
+
+    def test_single_process_exposes_metrics(self):
+        with patch.dict(os.environ, clear=False):
+            os.environ.pop("PROMETHEUS_MULTIPROC_DIR", None)
+            response = self.client.get(self.url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn("text/plain", response["Content-Type"])
+        self.assertIn(b"cohort360_jobs_in_progress", response.content)
+
+    def test_multiproc_dir_invalid_falls_back(self):
+        with patch.dict(os.environ, {"PROMETHEUS_MULTIPROC_DIR": "/nonexistent/path"}):
+            response = self.client.get(self.url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn(b"cohort360_jobs_in_progress", response.content)
+
+    @patch("admin_cohort.views.metrics.multiprocess.MultiProcessCollector")
+    def test_multiproc_dir_valid_registers_collector(self, mock_collector):
+        with tempfile.TemporaryDirectory() as tmp:
+            with patch.dict(os.environ, {"PROMETHEUS_MULTIPROC_DIR": tmp}):
+                response = self.client.get(self.url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        mock_collector.assert_called_once()
+        self.assertIn(b"cohort360_jobs_in_progress", response.content)

--- a/admin_cohort/urls.py
+++ b/admin_cohort/urls.py
@@ -17,6 +17,7 @@ from admin_cohort.views import (
     TokenRefreshView,
     LogoutView,
     NotFoundView,
+    metrics_view,
 )
 
 DOCS_ENDPOINT = "docs"
@@ -48,5 +49,5 @@ urlpatterns = [
     path(f"{DOCS_ENDPOINT}", SpectacularSwaggerView.as_view(), name="swagger-ui"),
     re_path(r"^schema", SpectacularAPIView.as_view(), name="schema"),
     re_path(r"^redoc/$", SpectacularRedocView.as_view(), name="redoc"),
-    path("", include("django_prometheus.urls")),
+    path("metrics", metrics_view, name="metrics"),
 ] + static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)

--- a/admin_cohort/views/__init__.py
+++ b/admin_cohort/views/__init__.py
@@ -5,6 +5,7 @@ from .maintenance_phase import MaintenancePhaseViewSet
 from .users import UserViewSet
 from .cache import CacheViewSet
 from .release_notes import ReleaseNotesViewSet
+from .metrics import metrics_view
 
 __all__ = [
     "LoginView",
@@ -17,4 +18,5 @@ __all__ = [
     "UserViewSet",
     "CacheViewSet",
     "ReleaseNotesViewSet",
+    "metrics_view",
 ]

--- a/admin_cohort/views/metrics.py
+++ b/admin_cohort/views/metrics.py
@@ -1,0 +1,17 @@
+import os
+
+import prometheus_client
+from django.http import HttpResponse
+from prometheus_client import multiprocess
+
+from admin_cohort.services.prometheus_metrics import JobsInProgressCollector
+
+
+def metrics_view(request):
+    if "PROMETHEUS_MULTIPROC_DIR" in os.environ:
+        registry = prometheus_client.CollectorRegistry()
+        multiprocess.MultiProcessCollector(registry)
+        registry.register(JobsInProgressCollector())
+    else:
+        registry = prometheus_client.REGISTRY
+    return HttpResponse(prometheus_client.generate_latest(registry), content_type=prometheus_client.CONTENT_TYPE_LATEST)

--- a/admin_cohort/views/metrics.py
+++ b/admin_cohort/views/metrics.py
@@ -8,7 +8,8 @@ from admin_cohort.services.prometheus_metrics import JobsInProgressCollector
 
 
 def metrics_view(request):
-    if "PROMETHEUS_MULTIPROC_DIR" in os.environ:
+    multiproc_dir = os.environ.get("PROMETHEUS_MULTIPROC_DIR")
+    if multiproc_dir and os.path.isdir(multiproc_dir):
         registry = prometheus_client.CollectorRegistry()
         multiprocess.MultiProcessCollector(registry)
         registry.register(JobsInProgressCollector())


### PR DESCRIPTION
## Objectif

Related to https://gitlab.data.aphp.fr/ID/design-et-produit/ipa/cohort360/gestion-de-projet/-/work_items/3287

Depuis le passage en multiprocess (#528), le custom collector `JobsInProgressCollector` n'était plus scrapé : `django_prometheus` sert un registry de requête ne contenant que le `MultiProcessCollector`, et les collectors du `REGISTRY` global sont ignorés. Résultat : `cohort360_jobs_in_progress` absent de `/metrics`.

## Changements

- `admin_cohort/views/metrics.py` : vue `/metrics` dédiée qui, en multiprocess, ajoute `JobsInProgressCollector` au registry de requête (à côté du `MultiProcessCollector`) ; retombe sur `REGISTRY` en single-process.
- `admin_cohort/urls.py` : route `metrics` vers cette vue à la place de `include("django_prometheus.urls")`.

## Validation

Vérifié en qualif : `cohort360_jobs_in_progress` de retour, Counter et Histogram (`exports_total`, `cohort_generation_duration_seconds`) remontent en conditions réelles.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a metrics endpoint for monitoring application performance and system health data.

* **Tests**
  * Added comprehensive test coverage for the metrics endpoint to ensure reliable operation across different deployment configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->