### PR TITLE
feat(monitoring): track query executor request duration by type

### DIFF
--- a/admin_cohort/services/prometheus_metrics.py
+++ b/admin_cohort/services/prometheus_metrics.py
@@ -11,11 +11,11 @@ EXPORTS_TOTAL = Counter(
     labelnames=("status", "output_format"),
 )
 
-COHORT_GENERATION_DURATION_SECONDS = Histogram(
-    "cohort360_cohort_generation_duration_seconds",
-    "Duration between cohort creation and terminal job status",
-    labelnames=("status",),
-    buckets=(1, 5, 10, 30, 60, 120, 300, 600, 1200, 1800, 3600),
+QUERY_EXECUTOR_REQUEST_DURATION_SECONDS = Histogram(
+    "cohort360_query_executor_request_duration_seconds",
+    "Duration between a query executor request and its terminal callback, by request type",
+    labelnames=("request_type", "status"),
+    buckets=(1, 5, 10, 30, 60, 120, 300, 600, 1200, 1800, 3600, 7200, 10800, 14400, 21600),
 )
 
 _ACTIVE_STATUSES = [s.value for s in JobStatus if not s.is_end_state and s != JobStatus.denied]

--- a/cohort_job_server/cohort_counter.py
+++ b/cohort_job_server/cohort_counter.py
@@ -4,6 +4,7 @@ from typing import Tuple, Optional
 
 from django.utils import timezone
 
+from admin_cohort.services.prometheus_metrics import QUERY_EXECUTOR_REQUEST_DURATION_SECONDS
 from admin_cohort.types import JobStatus
 from cohort_job_server.base_operator import BaseCohortOperator
 from cohort_job_server.query_executor_api import (
@@ -59,7 +60,10 @@ class CohortCounter(BaseCohortOperator):
         job_status = query_executor_status_mapper(data.get(JOB_STATUS))
         if not job_status:
             raise ValueError(f"Bad Request: Invalid job status: {data.get(JOB_STATUS)}")
-        job_duration = str(timezone.now() - dm.created_at)
+        duration = timezone.now() - dm.created_at
+        job_duration = str(duration)
+        if job_status in (JobStatus.finished, JobStatus.failed):
+            QUERY_EXECUTOR_REQUEST_DURATION_SECONDS.labels(request_type="count", status=job_status.value).observe(duration.total_seconds())
         if job_status == JobStatus.finished:
             data["measure"] = data.pop(COUNT, None)
             data["extra"] = data.pop(EXTRA, None)
@@ -82,6 +86,9 @@ class CohortCounter(BaseCohortOperator):
         try:
             if not job_status:
                 raise ValueError(f"Bad Request: Invalid job status: {data.get(JOB_STATUS)}")
+            if job_status in (JobStatus.finished, JobStatus.failed):
+                duration = timezone.now() - fs.created_at
+                QUERY_EXECUTOR_REQUEST_DURATION_SECONDS.labels(request_type="feasibility", status=job_status.value).observe(duration.total_seconds())
             if job_status == JobStatus.finished:
                 data["total_count"] = int(data.pop(COUNT, 0))
                 counts_per_perimeter = data.pop(EXTRA, {})

--- a/cohort_job_server/cohort_creator.py
+++ b/cohort_job_server/cohort_creator.py
@@ -3,7 +3,7 @@ from typing import Optional
 
 from django.utils import timezone
 
-from admin_cohort.services.prometheus_metrics import COHORT_GENERATION_DURATION_SECONDS
+from admin_cohort.services.prometheus_metrics import QUERY_EXECUTOR_REQUEST_DURATION_SECONDS
 from admin_cohort.types import JobStatus
 from cohort.models import CohortResult
 from cohort_job_server.apps import CohortJobServerConfig
@@ -49,7 +49,7 @@ class CohortCreator(BaseCohortOperator):
             if job_status in (JobStatus.finished, JobStatus.failed):
                 duration = timezone.now() - cohort.created_at
                 data["request_job_duration"] = str(duration)
-                COHORT_GENERATION_DURATION_SECONDS.labels(status=job_status.value).observe(duration.total_seconds())
+                QUERY_EXECUTOR_REQUEST_DURATION_SECONDS.labels(request_type="cohort", status=job_status.value).observe(duration.total_seconds())
                 if job_status == JobStatus.failed:
                     data["request_job_fail_msg"] = data.pop(ERR_MESSAGE, None)
                     logger.error(f"CohortResult[{cohort.uuid}] - Failed")


### PR DESCRIPTION
⚠️ A merge après #529 

## Objectif

Related to https://gitlab.data.aphp.fr/ID/design-et-produit/ipa/cohort360/gestion-de-projet/-/work_items/3174
Related to https://gitlab.data.aphp.fr/ID/design-et-produit/ipa/cohort360/gestion-de-projet/-/work_items/3297

Permettre de mesurer le temps de réponse des requêtes envoyées au query executor (SJS), de l'envoi jusqu'au callback terminal, pour benchmarker les performances.

## Changements

- `cohort360_cohort_generation_duration_seconds` remplacé par **`cohort360_query_executor_request_duration_seconds`**, avec un label `request_type` (`cohort` / `count` / `feasibility`) + `status`.
- Observé dans les trois callbacks du query executor : `handle_patch_cohort`, `handle_patch_dated_measure`, `handle_patch_feasibility_study` — la durée `now - created_at` y est calculée.
- Buckets élargis jusqu'à 6h (la requête de #3174 a tourné ~2h25) pour des percentiles exploitables.

## Validation

Tests des callbacks (`test_cohort_counter`, `test_cohort_creator`) ; `request_job_duration` inchangé côté payload.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated Prometheus metrics configuration to enhance observability of query execution and cohort processing operations.
  * Improved request duration tracking with expanded metrics labels and refined bucket configuration for better system monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->