### PR TITLE
feat(exports): support S3 storage for CSV/XLSX exports alongside HDFS

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,13 +246,27 @@ the [Cohort360 project](https://github.com/aphp/Cohort360) repository.
 
   For this, the following variables are required:
   
+  The storage backend used to read, stream and delete exported files is selected from the
+  file path scheme, mirroring the data-exporter convention: a path starting with `s3a://`
+  (or `s3://`) targets S3, anything else falls back to HDFS. Set `EXPORT_CSV_PATH` /
+  `EXPORT_XLSX_PATH` accordingly to choose where exports are written. The S3 bucket is read
+  from `S3_BUCKET`; `addressing_style` defaults to `path` (suitable for on-prem MinIO/Ceph).
+
   | Variable                    | Description                                                                  | Default Value | Required ? |
   |-----------------------------|------------------------------------------------------------------------------|---------------|------------|
-  | STORAGE_PROVIDERS           | Comma-separated URLs of servers to store exported data                       |               | `yes`      |
+  | STORAGE_PROVIDERS           | Comma-separated URLs of HDFS servers (required for HDFS-stored exports)       |               | no         |
+  | S3_ENDPOINT_URL             | S3 endpoint URL (required for S3-stored exports)                             |               | no         |
+  | S3_ACCESS_KEY               | S3 access key                                                                |               | no         |
+  | S3_SECRET_KEY               | S3 secret key                                                                |               | no         |
+  | S3_BUCKET                   | S3 bucket holding the exports (required for S3-stored exports)               |               | no         |
+  | S3_REGION_NAME              | S3 region                                                                    |               | no         |
+  | S3_ADDRESSING_STYLE         | S3 addressing style (`path` for MinIO/Ceph, `virtual`/`auto` for AWS)        | path          | no         |
+  | S3_CA_BUNDLE                | Path to a CA bundle for the S3 endpoint TLS cert (on-prem self-signed)       |               | no         |
+  | S3_VERIFY_SSL               | Set to `false` to disable S3 endpoint TLS verification                       | true          | no         |
   | EXPORT_API_URL              | URL of the third-party API that handles exports                              |               | `yes`      |
   | EXPORT_API_AUTH_TOKEN       | API-key used for authentication                                              |               | `yes`      |
-  | EXPORT_CSV_PATH             | Path to the directory where CSV exports are stored                           |               | `yes`      |
-  | EXPORT_XLSX_PATH            | Path to the directory where XLSX exports are stored                          |               | `yes`      |
+  | EXPORT_CSV_PATH             | Path where CSV exports are stored (prefix `s3a://` for S3, else HDFS)         |               | `yes`      |
+  | EXPORT_XLSX_PATH            | Path where XLSX exports are stored (prefix `s3a://` for S3, else HDFS)        |               | `yes`      |
   | HADOOP_API_URL              | URL of a third-party API that handles creating the database for Hive exports |               | `yes`      |
   | HADOOP_API_AUTH_TOKEN       | API-key used for authentication                                              |               | `yes`      |
   | HIVE_DB_PATH                | Path to the directory where the Hive database is stored                      |               | `yes`      |

--- a/exports/exceptions.py
+++ b/exports/exceptions.py
@@ -10,5 +10,5 @@ class StorageProviderException(Exception):
     pass
 
 
-class HdfsServerUnreachable(Exception):
+class HdfsServerUnreachable(StorageProviderException):
     pass

--- a/exports/services/export_operators.py
+++ b/exports/services/export_operators.py
@@ -1,5 +1,4 @@
 import logging
-import os
 from datetime import timedelta
 
 from django.conf import settings
@@ -14,14 +13,10 @@ from exports.apps import ExportsConfig
 from exports.emails import push_email_notification, exported_files_deleted
 from exports.exceptions import BadRequestError, FilesNoLongerAvailable, StorageProviderException
 from exports.models import Export
-from exports.services.storage_provider import HDFSStorageProvider
+from exports.services.storage_provider import StorageProvider, get_storage_provider, storage_scheme
 
 
 logger = logging.getLogger(__name__)
-
-STORAGE_PROVIDERS = os.environ.get("STORAGE_PROVIDERS", "").split(",")
-if not STORAGE_PROVIDERS:
-    logger.warning("No storage provider is configured!")
 
 ExportTypes = ExportsConfig.ExportTypes
 EXPORTERS = ExportsConfig.EXPORTERS
@@ -93,7 +88,6 @@ class DefaultExporter:
 
 class ExportDownloader:
     def __init__(self):
-        self.storage_provider = HDFSStorageProvider(servers_urls=STORAGE_PROVIDERS)
         self.downloadable_export_types = [t.value for t in ExportTypes if t.allow_download]
 
     def download(self, export: Export) -> StreamingHttpResponse:
@@ -101,10 +95,11 @@ class ExportDownloader:
             raise BadRequestError("The export is not done yet or has failed or not downloadable")
         if not export.available_for_download():
             raise FilesNoLongerAvailable("The exported files are no longer available on the server.")
+        file_path = f"{export.target_full_path}.zip"
         try:
-            file_path = f"{export.target_full_path}.zip"
-            response = StreamingHttpResponse(streaming_content=self.stream_file(file_path))
-            file_size = self.get_file_size(file_name=file_path)
+            storage_provider = get_storage_provider(file_path)
+            response = StreamingHttpResponse(streaming_content=self.stream_file(storage_provider, file_path))
+            file_size = storage_provider.get_file_size(file_name=file_path)
             first = export.export_tables.first()
             if first is None or first.cohort_result_source is None:
                 raise BadRequestError("Export has no table with cohort result source")
@@ -114,21 +109,22 @@ class ExportDownloader:
             response["Content-Disposition"] = f"attachment; filename={download_file_name}"
             return response
         except StorageProviderException as e:
-            logger.exception(f"Error occurred on Storage Provider `{self.storage_provider.name}` - {e}")
+            logger.exception(f"Export {export.pk}: error on `{storage_scheme(file_path)}` storage provider - {e}")
             raise e
 
-    def stream_file(self, file_name: str):
-        with self.storage_provider.stream_file(file_name=file_name) as f:
-            for chunk in f:
-                yield chunk
-
-    def get_file_size(self, file_name: str) -> int:
-        return self.storage_provider.get_file_size(file_name=file_name)
+    @staticmethod
+    def stream_file(storage_provider: StorageProvider, file_name: str):
+        try:
+            with storage_provider.stream_file(file_name=file_name) as f:
+                for chunk in f:
+                    yield chunk
+        except StorageProviderException:
+            logger.exception(f"Error while streaming `{file_name}` from storage provider")
+            raise
 
 
 class ExportCleaner:
     def __init__(self):
-        self.storage_provider = HDFSStorageProvider(servers_urls=STORAGE_PROVIDERS)
         self.target_types = [t.value for t in ExportTypes if t.allow_to_clean]
 
     def delete_exported_files(self):
@@ -140,9 +136,14 @@ class ExportCleaner:
             created_at__lte=d,
             clean_datetime__isnull=True,
         )
+        providers: dict[str, StorageProvider] = {}
         for export in exports:
+            file_path = f"{export.target_full_path}.zip"
+            scheme = storage_scheme(file_path)
             try:
-                self.storage_provider.delete_file(file_name=f"{export.target_full_path}.zip")
+                provider = providers.get(scheme) or get_storage_provider(file_path)
+                providers[scheme] = provider
+                provider.delete_file(file_name=file_path)
             except (RequestException, StorageProviderException) as e:
                 logger.exception(f"Export {export.pk}: {e}")
                 return

--- a/exports/services/storage_provider.py
+++ b/exports/services/storage_provider.py
@@ -1,18 +1,24 @@
 import functools
+import os
+import re
+from contextlib import contextmanager
 from typing import List
 
+import boto3
+from botocore.config import Config
+from botocore.exceptions import BotoCoreError, ClientError
 from hdfs import HdfsError
 from hdfs.ext.kerberos import KerberosClient
 
 from exports.exceptions import HdfsServerUnreachable, StorageProviderException
 
+S3_PATH_PREFIXES = ("s3://", "s3a://")
+# An S3 URI is s3a://<bucket>/<key>: the bucket is the first path segment.
+S3_URI_PATTERN = re.compile(r"^s3a?://(?P<bucket>[^/]+)/(?P<key>.+)$")
+
 
 class StorageProvider:
     name: str | None = None
-
-    def __init__(self, servers_urls: List[str]):
-        self.servers_urls = servers_urls
-        self.client = self.get_client()
 
     def get_client(self):
         """
@@ -48,6 +54,10 @@ class StorageProvider:
 class HDFSStorageProvider(StorageProvider):
     name = "HDFS"
 
+    def __init__(self, servers_urls: List[str]):
+        self.servers_urls = servers_urls
+        self.client = self.get_client()
+
     def get_client(self):
         for server in self.servers_urls:
             client = KerberosClient(server)
@@ -80,3 +90,127 @@ class HDFSStorageProvider(StorageProvider):
     @catch_hdfs_error
     def delete_file(self, file_name: str):
         self.client.delete(hdfs_path=file_name)
+
+
+class S3StorageProvider(StorageProvider):
+    name = "S3"
+    chunk_size = 1000000
+
+    def __init__(
+        self,
+        endpoint_url: str | None,
+        access_key: str | None,
+        secret_key: str | None,
+        bucket: str | None,
+        region_name: str | None = None,
+        addressing_style: str = "path",
+        verify: bool | str | None = None,
+    ):
+        self.endpoint_url = endpoint_url
+        self.access_key = access_key
+        self.secret_key = secret_key
+        self.bucket = bucket
+        self.region_name = region_name
+        self.addressing_style = addressing_style
+        self.verify = verify
+        self.client = self.get_client()
+
+    def get_client(self):
+        return boto3.client(
+            "s3",
+            endpoint_url=self.endpoint_url,
+            aws_access_key_id=self.access_key,
+            aws_secret_access_key=self.secret_key,
+            region_name=self.region_name,
+            verify=self.verify,
+            config=Config(s3={"addressing_style": self.addressing_style}),
+        )
+
+    def object_key(self, file_name: str) -> str:
+        """
+        Return the object key from a `s3a://<bucket>/<key>` path. The bucket must match
+        the configured one, and traversal segments (`..`, `//`) are not allowed.
+        """
+        if not self.bucket:
+            raise StorageProviderException("S3 bucket is not configured")
+        match = S3_URI_PATTERN.match(file_name)
+        if not match:
+            raise StorageProviderException(f"Invalid S3 path: `{file_name}`")
+        bucket, key = match.group("bucket"), match.group("key")
+        if bucket != self.bucket:
+            raise StorageProviderException(f"S3 bucket mismatch: path targets `{bucket}` but `{self.bucket}` is configured")
+        if "//" in key or ".." in key.split("/"):
+            raise StorageProviderException(f"Invalid S3 object key: `{key}`")
+        return key
+
+    @staticmethod
+    def catch_s3_error(func):
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            try:
+                return func(*args, **kwargs)
+            except (BotoCoreError, ClientError) as e:
+                raise StorageProviderException(str(e))
+
+        return wrapper
+
+    @catch_s3_error
+    def get_file_size(self, file_name: str) -> int:
+        return self.client.head_object(Bucket=self.bucket, Key=self.object_key(file_name))["ContentLength"]
+
+    @contextmanager
+    def stream_file(self, file_name: str):
+        key = self.object_key(file_name)
+        try:
+            body = self.client.get_object(Bucket=self.bucket, Key=key)["Body"]
+        except (BotoCoreError, ClientError) as e:
+            raise StorageProviderException(str(e))
+        try:
+            yield body.iter_chunks(chunk_size=self.chunk_size)
+        finally:
+            body.close()
+
+    @catch_s3_error
+    def delete_file(self, file_name: str):
+        self.client.delete_object(Bucket=self.bucket, Key=self.object_key(file_name))
+
+
+def is_s3_path(file_name: str) -> bool:
+    return file_name.startswith(S3_PATH_PREFIXES)
+
+
+def storage_scheme(file_name: str) -> str:
+    return "s3" if is_s3_path(file_name) else "hdfs"
+
+
+def s3_verify() -> bool | str | None:
+    """
+    Resolve the boto3 `verify` argument for on-prem TLS: a CA bundle path
+    (`S3_CA_BUNDLE`), `False` to disable verification (`S3_VERIFY_SSL=false`), or
+    `None` to use the system trust store.
+    """
+    ca_bundle = os.environ.get("S3_CA_BUNDLE")
+    if ca_bundle:
+        return ca_bundle
+    if os.environ.get("S3_VERIFY_SSL", "true").lower() in ("false", "0", "no"):
+        return False
+    return None
+
+
+def get_storage_provider(file_name: str) -> StorageProvider:
+    """
+    Return the storage provider matching the file path scheme, mirroring the
+    data-exporter convention: an `s3a://` (or `s3://`) prefix targets S3,
+    anything else falls back to HDFS.
+    """
+    if is_s3_path(file_name):
+        return S3StorageProvider(
+            endpoint_url=os.environ.get("S3_ENDPOINT_URL"),
+            access_key=os.environ.get("S3_ACCESS_KEY"),
+            secret_key=os.environ.get("S3_SECRET_KEY"),
+            bucket=os.environ.get("S3_BUCKET"),
+            region_name=os.environ.get("S3_REGION_NAME"),
+            addressing_style=os.environ.get("S3_ADDRESSING_STYLE", "path"),
+            verify=s3_verify(),
+        )
+    return HDFSStorageProvider(servers_urls=os.environ.get("STORAGE_PROVIDERS", "").split(","))

--- a/exports/services/storage_provider.py
+++ b/exports/services/storage_provider.py
@@ -165,8 +165,15 @@ class S3StorageProvider(StorageProvider):
             body = self.client.get_object(Bucket=self.bucket, Key=key)["Body"]
         except (BotoCoreError, ClientError) as e:
             raise StorageProviderException(str(e))
+
+        def chunks():
+            try:
+                yield from body.iter_chunks(chunk_size=self.chunk_size)
+            except (BotoCoreError, ClientError) as e:
+                raise StorageProviderException(str(e))
+
         try:
-            yield body.iter_chunks(chunk_size=self.chunk_size)
+            yield chunks()
         finally:
             body.close()
 
@@ -213,4 +220,5 @@ def get_storage_provider(file_name: str) -> StorageProvider:
             addressing_style=os.environ.get("S3_ADDRESSING_STYLE", "path"),
             verify=s3_verify(),
         )
-    return HDFSStorageProvider(servers_urls=os.environ.get("STORAGE_PROVIDERS", "").split(","))
+    servers_urls = [url.strip() for url in os.environ.get("STORAGE_PROVIDERS", "").split(",") if url.strip()]
+    return HDFSStorageProvider(servers_urls=servers_urls)

--- a/exports/tests/test_export_cleaner.py
+++ b/exports/tests/test_export_cleaner.py
@@ -16,9 +16,14 @@ from exports.tests.test_view_export_request import ExportsTests
 class TestExportCleaner(ExportsTests):
     def setUp(self):
         super().setUp()
-        with mock.patch("exports.services.export_operators.HDFSStorageProvider"):
-            self.export_cleaner = ExportCleaner()
-            self.mock_storage_provider = self.export_cleaner.storage_provider
+        self.export_cleaner = ExportCleaner()
+        self.mock_storage_provider = MagicMock()
+        patcher = mock.patch(
+            "exports.services.export_operators.get_storage_provider",
+            return_value=self.mock_storage_provider,
+        )
+        self.mock_get_storage_provider = patcher.start()
+        self.addCleanup(patcher.stop)
 
         cleanable_export_types = [t.value for t in ExportsConfig.ExportTypes if t.allow_to_clean]
 
@@ -27,6 +32,7 @@ class TestExportCleaner(ExportsTests):
             output_format=cleanable_export_types and cleanable_export_types[0] or None,
             request_job_status=JobStatus.finished,
             target_location="target_location",
+            target_name="target_name",
             is_user_notified=True,
             nominative=True,
         )
@@ -42,10 +48,22 @@ class TestExportCleaner(ExportsTests):
         mock_push_notification.return_value = None
         self.update_export_insert_datetime()
         self.export_cleaner.delete_exported_files()
+        self.mock_get_storage_provider.assert_called_once_with("target_location/target_name.zip")
         self.mock_storage_provider.delete_file.assert_called_once()
         mock_push_notification.assert_called_once()
         self.export1.refresh_from_db()
         self.assertIsNotNone(self.export1.clean_datetime)
+
+    @mock.patch("exports.services.export_operators.push_email_notification")
+    def test_delete_exported_files_on_s3(self, mock_push_notification: MagicMock):
+        self.export1.target_location = "s3a://bucket/exports"
+        self.export1.save()
+        self.mock_storage_provider.delete_file.return_value = None
+        mock_push_notification.return_value = None
+        self.update_export_insert_datetime()
+        self.export_cleaner.delete_exported_files()
+        self.mock_get_storage_provider.assert_called_once_with("s3a://bucket/exports/target_name.zip")
+        self.mock_storage_provider.delete_file.assert_called_once_with(file_name="s3a://bucket/exports/target_name.zip")
 
     @mock.patch("exports.services.export_operators.push_email_notification")
     def test_error_delete_exported_files(self, mock_push_notification: MagicMock):

--- a/exports/tests/test_export_cleaner.py
+++ b/exports/tests/test_export_cleaner.py
@@ -49,7 +49,7 @@ class TestExportCleaner(ExportsTests):
         self.update_export_insert_datetime()
         self.export_cleaner.delete_exported_files()
         self.mock_get_storage_provider.assert_called_once_with("target_location/target_name.zip")
-        self.mock_storage_provider.delete_file.assert_called_once()
+        self.mock_storage_provider.delete_file.assert_called_once_with(file_name="target_location/target_name.zip")
         mock_push_notification.assert_called_once()
         self.export1.refresh_from_db()
         self.assertIsNotNone(self.export1.clean_datetime)

--- a/exports/tests/test_export_downloader.py
+++ b/exports/tests/test_export_downloader.py
@@ -1,6 +1,6 @@
 from datetime import timedelta
 from unittest import mock
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 from django.conf import settings
 from django.utils import timezone
@@ -17,9 +17,14 @@ from exports.tests.test_view_export_request import ExportsTests
 class TestExportDownloader(ExportsTests):
     def setUp(self):
         super().setUp()
-        with mock.patch("exports.services.export_operators.HDFSStorageProvider"):
-            self.export_downloader = ExportDownloader()
-            self.mock_storage_provider = self.export_downloader.storage_provider
+        self.export_downloader = ExportDownloader()
+        self.mock_storage_provider = MagicMock()
+        patcher = mock.patch(
+            "exports.services.export_operators.get_storage_provider",
+            return_value=self.mock_storage_provider,
+        )
+        self.mock_get_storage_provider = patcher.start()
+        self.addCleanup(patcher.stop)
 
         downloadable_export_types = [t.value for t in ExportsConfig.ExportTypes if t.allow_download]
 
@@ -28,20 +33,33 @@ class TestExportDownloader(ExportsTests):
             output_format=downloadable_export_types and downloadable_export_types[0] or None,
             request_job_status=JobStatus.finished,
             target_location="target_location",
+            target_name="target_name",
             is_user_notified=True,
             nominative=True,
         )
         ExportTable.objects.create(export=self.export1, name="Patient", cohort_result_source=self.user1_cohort)
 
+    def _mock_stream_chunks(self, *chunks):
+        mock_file = MagicMock()
+        mock_file.__iter__.return_value = iter(chunks)
+        self.mock_storage_provider.stream_file.return_value.__enter__.return_value = mock_file
+
     def test_successfully_download_export(self):
         self.mock_storage_provider.get_file_size.return_value = 11111
-        with patch.object(self.export_downloader.storage_provider, "stream_file") as mock_stream_file:
-            mock_file = MagicMock()
-            mock_stream_file.return_value.__enter__.return_value = mock_file
-            mock_file.__iter__.return_value = iter(["chunk1", "chunk2"])
-            response = self.export_downloader.download(self.export1)
+        self._mock_stream_chunks("chunk1", "chunk2")
+        response = self.export_downloader.download(self.export1)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.mock_get_storage_provider.assert_called_once_with("target_location/target_name.zip")
         self.mock_storage_provider.get_file_size.assert_called_once()
+
+    def test_successfully_download_export_from_s3(self):
+        self.export1.target_location = "s3a://bucket/exports"
+        self.export1.save()
+        self.mock_storage_provider.get_file_size.return_value = 11111
+        self._mock_stream_chunks("chunk1", "chunk2")
+        response = self.export_downloader.download(self.export1)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.mock_get_storage_provider.assert_called_once_with("s3a://bucket/exports/target_name.zip")
 
     def test_error_download_export_type_plain(self):
         self.export1.output_format = "bad_format"

--- a/exports/tests/test_storage_provider.py
+++ b/exports/tests/test_storage_provider.py
@@ -99,6 +99,21 @@ class TestS3StorageProvider(TestCase):
             with provider.stream_file("s3a://bucket/key.zip"):
                 pass
 
+    def test_stream_file_wraps_mid_stream_error(self, mock_boto3):
+        provider, client = self._build_provider(mock_boto3)
+        body = MagicMock()
+
+        def chunks(chunk_size):
+            yield b"a"
+            raise self._client_error("GetObject")
+
+        body.iter_chunks.side_effect = chunks
+        client.get_object.return_value = {"Body": body}
+        with self.assertRaises(StorageProviderException):
+            with provider.stream_file("s3a://bucket/key.zip") as stream:
+                list(stream)
+        body.close.assert_called_once()
+
     def test_delete_file(self, mock_boto3):
         provider, client = self._build_provider(mock_boto3)
         provider.delete_file("s3a://bucket/key.zip")

--- a/exports/tests/test_storage_provider.py
+++ b/exports/tests/test_storage_provider.py
@@ -1,0 +1,156 @@
+from unittest import TestCase, mock
+from unittest.mock import MagicMock
+
+from botocore.exceptions import ClientError
+
+from exports.exceptions import HdfsServerUnreachable, StorageProviderException
+from exports.services.storage_provider import (
+    S3StorageProvider,
+    get_storage_provider,
+    is_s3_path,
+    storage_scheme,
+)
+
+
+class TestS3PathHelpers(TestCase):
+    def test_is_s3_path(self):
+        self.assertTrue(is_s3_path("s3a://bucket/key.zip"))
+        self.assertTrue(is_s3_path("s3://bucket/key.zip"))
+        self.assertFalse(is_s3_path("hdfs://namenode/user/exports/file.zip"))
+        self.assertFalse(is_s3_path("/user/exports/file.zip"))
+
+    def test_storage_scheme(self):
+        self.assertEqual(storage_scheme("s3a://bucket/key.zip"), "s3")
+        self.assertEqual(storage_scheme("/user/exports/file.zip"), "hdfs")
+
+    def test_hdfs_unreachable_is_a_storage_provider_exception(self):
+        # ensures the view / services that catch StorageProviderException also handle it
+        self.assertTrue(issubclass(HdfsServerUnreachable, StorageProviderException))
+
+
+@mock.patch("exports.services.storage_provider.boto3")
+class TestS3StorageProvider(TestCase):
+    def _build_provider(self, mock_boto3, bucket="bucket"):
+        client = MagicMock()
+        mock_boto3.client.return_value = client
+        provider = S3StorageProvider(endpoint_url="http://s3", access_key="ak", secret_key="sk", bucket=bucket)
+        return provider, client
+
+    @staticmethod
+    def _client_error(operation):
+        return ClientError({"Error": {"Code": "NoSuchKey", "Message": "missing"}}, operation)
+
+    def test_object_key(self, mock_boto3):
+        provider, _ = self._build_provider(mock_boto3)
+        self.assertEqual(provider.object_key("s3a://bucket/exports/123.zip"), "exports/123.zip")
+        self.assertEqual(provider.object_key("s3://bucket/exports/123.zip"), "exports/123.zip")
+        # a key segment that happens to equal the bucket name is preserved
+        self.assertEqual(provider.object_key("s3a://bucket/bucket/123.zip"), "bucket/123.zip")
+
+    def test_object_key_requires_bucket(self, mock_boto3):
+        provider, _ = self._build_provider(mock_boto3, bucket=None)
+        with self.assertRaises(StorageProviderException):
+            provider.object_key("s3a://bucket/exports/123.zip")
+
+    def test_object_key_rejects_bucket_mismatch(self, mock_boto3):
+        provider, _ = self._build_provider(mock_boto3, bucket="bucket")
+        with self.assertRaises(StorageProviderException):
+            provider.object_key("s3a://other-bucket/exports/123.zip")
+
+    def test_object_key_rejects_malformed_path(self, mock_boto3):
+        provider, _ = self._build_provider(mock_boto3)
+        for bad in ("s3a://bucket", "s3a://bucket/", "s3a://"):
+            with self.assertRaises(StorageProviderException):
+                provider.object_key(bad)
+
+    def test_object_key_rejects_traversal(self, mock_boto3):
+        provider, _ = self._build_provider(mock_boto3)
+        for bad in ("s3a://bucket/../secret.zip", "s3a://bucket/exports//123.zip", "s3a://bucket/a/../../b.zip"):
+            with self.assertRaises(StorageProviderException):
+                provider.object_key(bad)
+
+    def test_get_file_size(self, mock_boto3):
+        provider, client = self._build_provider(mock_boto3)
+        client.head_object.return_value = {"ContentLength": 4242}
+        size = provider.get_file_size("s3a://bucket/exports/123.zip")
+        self.assertEqual(size, 4242)
+        client.head_object.assert_called_once_with(Bucket="bucket", Key="exports/123.zip")
+
+    def test_get_file_size_wraps_client_error(self, mock_boto3):
+        provider, client = self._build_provider(mock_boto3)
+        client.head_object.side_effect = self._client_error("HeadObject")
+        with self.assertRaises(StorageProviderException):
+            provider.get_file_size("s3a://bucket/exports/123.zip")
+
+    def test_stream_file(self, mock_boto3):
+        provider, client = self._build_provider(mock_boto3)
+        body = MagicMock()
+        body.iter_chunks.return_value = iter([b"a", b"b"])
+        client.get_object.return_value = {"Body": body}
+        with provider.stream_file("s3a://bucket/key.zip") as chunks:
+            self.assertEqual(list(chunks), [b"a", b"b"])
+        client.get_object.assert_called_once_with(Bucket="bucket", Key="key.zip")
+        body.close.assert_called_once()
+
+    def test_stream_file_wraps_client_error(self, mock_boto3):
+        provider, client = self._build_provider(mock_boto3)
+        client.get_object.side_effect = self._client_error("GetObject")
+        with self.assertRaises(StorageProviderException):
+            with provider.stream_file("s3a://bucket/key.zip"):
+                pass
+
+    def test_delete_file(self, mock_boto3):
+        provider, client = self._build_provider(mock_boto3)
+        provider.delete_file("s3a://bucket/key.zip")
+        client.delete_object.assert_called_once_with(Bucket="bucket", Key="key.zip")
+
+    def test_delete_file_wraps_client_error(self, mock_boto3):
+        provider, client = self._build_provider(mock_boto3)
+        client.delete_object.side_effect = self._client_error("DeleteObject")
+        with self.assertRaises(StorageProviderException):
+            provider.delete_file("s3a://bucket/key.zip")
+
+    def test_uses_path_addressing_style(self, mock_boto3):
+        self._build_provider(mock_boto3)
+        _, kwargs = mock_boto3.client.call_args
+        self.assertEqual(kwargs["config"].s3["addressing_style"], "path")
+
+
+class TestGetStorageProvider(TestCase):
+    @mock.patch.dict(
+        "os.environ",
+        {"S3_ENDPOINT_URL": "http://s3", "S3_ACCESS_KEY": "ak", "S3_SECRET_KEY": "sk", "S3_BUCKET": "bucket"},
+    )
+    @mock.patch("exports.services.storage_provider.boto3")
+    def test_returns_s3_provider_for_s3_path(self, mock_boto3):
+        provider = get_storage_provider("s3a://bucket/key.zip")
+        self.assertIsInstance(provider, S3StorageProvider)
+        self.assertEqual(provider.name, "S3")
+        self.assertEqual(provider.bucket, "bucket")
+
+    @mock.patch.dict("os.environ", {"S3_BUCKET": "bucket", "S3_VERIFY_SSL": "false", "S3_CA_BUNDLE": ""})
+    @mock.patch("exports.services.storage_provider.boto3")
+    def test_verify_disabled_via_env(self, mock_boto3):
+        get_storage_provider("s3a://bucket/key.zip")
+        _, kwargs = mock_boto3.client.call_args
+        self.assertIs(kwargs["verify"], False)
+
+    @mock.patch.dict("os.environ", {"S3_BUCKET": "bucket", "S3_CA_BUNDLE": "/etc/ssl/internal-ca.pem"})
+    @mock.patch("exports.services.storage_provider.boto3")
+    def test_verify_uses_ca_bundle(self, mock_boto3):
+        get_storage_provider("s3a://bucket/key.zip")
+        _, kwargs = mock_boto3.client.call_args
+        self.assertEqual(kwargs["verify"], "/etc/ssl/internal-ca.pem")
+
+    @mock.patch.dict("os.environ", {"S3_BUCKET": "bucket", "S3_CA_BUNDLE": "", "S3_VERIFY_SSL": "true"})
+    @mock.patch("exports.services.storage_provider.boto3")
+    def test_verify_defaults_to_system_trust_store(self, mock_boto3):
+        get_storage_provider("s3a://bucket/key.zip")
+        _, kwargs = mock_boto3.client.call_args
+        self.assertIsNone(kwargs["verify"])
+
+    @mock.patch.dict("os.environ", {"STORAGE_PROVIDERS": "http://namenode"})
+    @mock.patch("exports.services.storage_provider.HDFSStorageProvider")
+    def test_returns_hdfs_provider_for_non_s3_path(self, mock_hdfs):
+        get_storage_provider("hdfs://namenode/user/exports/file.zip")
+        mock_hdfs.assert_called_once_with(servers_urls=["http://namenode"])

--- a/exports/views/export.py
+++ b/exports/views/export.py
@@ -138,8 +138,8 @@ class ExportViewSet(RequestLogMixin, ExportsBaseViewSet):
             return export_service.download(export=self.get_object())
         except (BadRequestError, FilesNoLongerAvailable) as e:
             return Response(data=f"Error downloading files: {e}", status=status.HTTP_400_BAD_REQUEST)
-        except StorageProviderException as e:
-            return Response(data=f"Storage provider error: {e}", status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+        except StorageProviderException:
+            return Response(data="A storage provider error occurred while downloading the files", status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
     @extend_schema(responses={status.HTTP_200_OK: OpenApiTypes.STR})
     @action(detail=True, methods=["post"], url_path="retry")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,8 @@ readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
     "asgiref>=3.8",
+    "boto3>=1.34",
+    "botocore>=1.34",
     "channels-redis>=4.2.1",
     "channels>=4.2.0",
     "coverage>=7.6.9",

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.12"
 resolution-markers = [
     "python_full_version >= '3.15'",
@@ -144,6 +144,34 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/7c/58/1546c970afcd2a2428b1bfafecf2371d8951cc34b46701bea73f4280989e/billiard-4.2.1.tar.gz", hash = "sha256:12b641b0c539073fc8d3f5b8b7be998956665c4233c7c1fcd66a7e677c4fb36f", size = 155031, upload-time = "2024-09-21T13:40:22.491Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/30/da/43b15f28fe5f9e027b41c539abc5469052e9d48fd75f8ff094ba2a0ae767/billiard-4.2.1-py3-none-any.whl", hash = "sha256:40b59a4ac8806ba2c2369ea98d876bc6108b051c227baffd928c644d15d8f3cb", size = 86766, upload-time = "2024-09-21T13:40:20.188Z" },
+]
+
+[[package]]
+name = "boto3"
+version = "1.43.27"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+    { name = "jmespath" },
+    { name = "s3transfer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7e/ad/32ac82224c571776d1119c8d2a5eafeab97bace3b4ed2870cb80d5cda140/boto3-1.43.27.tar.gz", hash = "sha256:dc0d1b47f391983d8b3047e49402d31f9aaa4d7b398d3b4ea986fe680cbea43a", size = 113143, upload-time = "2026-06-10T19:38:35.874Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/1b/e423f7ed0177f0cc629f9bba39f505ad4a571b1f73c51402e6000bbf453b/boto3-1.43.27-py3-none-any.whl", hash = "sha256:b3eea072c2fdbbdd8c6161f912f603be10c8ec477625926dea8b91a0842a3482", size = 140538, upload-time = "2026-06-10T19:38:34.012Z" },
+]
+
+[[package]]
+name = "botocore"
+version = "1.43.27"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jmespath" },
+    { name = "python-dateutil" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fa/4e/db50ef135f1d9ffc85e209a124004a5829d8f12f4a7a0afdf380cb19866d/botocore-1.43.27.tar.gz", hash = "sha256:2093c316c24214e50e18640b1869513b759bb8cc48b95b004a8306cb9f0d6703", size = 15504242, upload-time = "2026-06-10T19:38:25.389Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2d/46/05b227b34e434b54867c2c942b0bfbbe2fe41789c18bb15ef787d03e9a56/botocore-1.43.27-py3-none-any.whl", hash = "sha256:4976544e652d5a1d8eca135da019f8e1c2d749efa2f9a31a8fb8c76f1895a40b", size = 15190293, upload-time = "2026-06-10T19:38:22.298Z" },
 ]
 
 [[package]]
@@ -330,6 +358,8 @@ version = "3.29.0.dev0"
 source = { virtual = "." }
 dependencies = [
     { name = "asgiref" },
+    { name = "boto3" },
+    { name = "botocore" },
     { name = "celery" },
     { name = "channels" },
     { name = "channels-redis" },
@@ -382,6 +412,8 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "asgiref", specifier = ">=3.8" },
+    { name = "boto3", specifier = ">=1.34" },
+    { name = "botocore", specifier = ">=1.34" },
     { name = "celery", specifier = ">=5.4.0" },
     { name = "channels", specifier = ">=4.2.0" },
     { name = "channels-redis", specifier = ">=4.2.1" },
@@ -1029,6 +1061,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d7/4b/cbd8e699e64a6f16ca3a8220661b5f83792b3017d0f79807cb8708d33913/iniconfig-2.0.0.tar.gz", hash = "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3", size = 4646, upload-time = "2023-01-07T11:08:11.254Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374", size = 5892, upload-time = "2023-01-07T11:08:09.864Z" },
+]
+
+[[package]]
+name = "jmespath"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/59/322338183ecda247fb5d1763a6cbe46eff7222eaeebafd9fa65d4bf5cb11/jmespath-1.1.0.tar.gz", hash = "sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d", size = 27377, upload-time = "2026-01-22T16:35:26.279Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl", hash = "sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64", size = 20419, upload-time = "2026-01-22T16:35:24.919Z" },
 ]
 
 [[package]]
@@ -1725,6 +1766,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/30/89/35fc7a6cdf3477d441c7aca5e9bbf5a14e0f25152aed7f63f4e0b141045d/rpds_py-0.22.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:a76e42402542b1fae59798fab64432b2d015ab9d0c8c47ba7addddbaf7952333", size = 553855, upload-time = "2024-12-04T15:33:10Z" },
     { url = "https://files.pythonhosted.org/packages/8f/e0/830c02b2457c4bd20a8c5bb394d31d81f57fbefce2dbdd2e31feff4f7003/rpds_py-0.22.3-cp313-cp313t-win32.whl", hash = "sha256:69803198097467ee7282750acb507fba35ca22cc3b85f16cf45fb01cb9097730", size = 219100, upload-time = "2024-12-04T15:33:11.343Z" },
     { url = "https://files.pythonhosted.org/packages/f8/30/7ac943f69855c2db77407ae363484b915d861702dbba1aa82d68d57f42be/rpds_py-0.22.3-cp313-cp313t-win_amd64.whl", hash = "sha256:f5cf2a0c2bdadf3791b5c205d55a37a54025c6e18a71c71f82bb536cf9a454bf", size = 233794, upload-time = "2024-12-04T15:33:12.888Z" },
+]
+
+[[package]]
+name = "s3transfer"
+version = "0.18.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e0/1f/12417f7f493fc45e1f9fd5d4a9b6c125cf8d2cf3f8ddbdfab3e76406e9d6/s3transfer-0.18.0.tar.gz", hash = "sha256:3760b8b7ec1315da54048b2d626276732bee4300d054d492d4e1d43e20d4ecbd", size = 160560, upload-time = "2026-05-28T19:39:09.124Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2b/58/a58fc997655386daa2e25784e30c288aa3e3819e401f77029ee4899fb55a/s3transfer-0.18.0-py3-none-any.whl", hash = "sha256:239c13b09e65ad0346e1be7348b8a202dcad44ac7ea7c6eb858fc881dce739b6", size = 88572, upload-time = "2026-05-28T19:39:07.999Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Objectif
Permettre le stockage des exports CSV/XLSX sur S3 (objet on-prem MinIO/Ceph) en plus de HDFS, pour sortir de la dépendance Hadoop, sans casser l'existant.
Fixes https://gitlab.data.aphp.fr/ID/design-et-produit/ipa/cohort360/gestion-de-projet/-/work_items/2468

## Changements réalisés
- Ajout d'un `S3StorageProvider` (boto3) à côté de `HDFSStorageProvider`.
- Sélection du backend selon le préfixe du path, en miroir de la convention du data-exporter ([data-exporter#104](https://gitlab.data.aphp.fr/ID/isd/data-engineering/data-exporter/-/issues/104)) : `s3a://`/`s3://` vise S3, sinon HDFS.
- `ExportDownloader` et `ExportCleaner` résolvent le provider par export au lieu d'être figés sur HDFS ; la boucle de nettoyage mutualise un provider par schéma.
- Path S3 parsé en `s3a://<bucket>/<key>` : le bucket doit correspondre à `S3_BUCKET`, les clés de traversal (`..`, `//`) sont rejetées.
- `addressing_style` par défaut `path` (MinIO/Ceph) et TLS configurable via `S3_CA_BUNDLE` / `S3_VERIFY_SSL`.
- `HdfsServerUnreachable` hérite de `StorageProviderException` (gérée comme les autres erreurs de stockage) ; les détails d'erreur de stockage sont loggés côté serveur, plus renvoyés au client.

## Impacts
- **Back / exports / jobs de cleanup** uniquement. Pas d'impact front ni DB (aucune migration).
- L'écriture S3 est pilotée par config (`EXPORT_CSV_PATH` / `EXPORT_XLSX_PATH` préfixés `s3a://`), côté infra.
- Nouvelles dépendances : `boto3`, `botocore`.

## Tests réalisés
- Unitaires : nouveau `test_storage_provider` (parsing, mismatch bucket, anti-traversal, conversion `ClientError`/`BotoCoreError` en `StorageProviderException`, TLS verify, sélection par schéma) ; `test_export_downloader` et `test_export_cleaner` mis à jour avec cas S3.

## Risques
- **Activation côté infra requise** (le merge seul ne bascule rien) : créer les secrets `S3_ENDPOINT_URL` / `S3_ACCESS_KEY` / `S3_SECRET_KEY` / `S3_BUCKET` dans Vault (absents aujourd'hui), provisionner les buckets par environnement, et positionner `EXPORT_CSV_PATH = s3a://${S3_BUCKET}/...`. Une incohérence bucket path/config lève une erreur explicite (pas de suppression silencieuse du mauvais objet).
- Cert TLS interne MinIO/Ceph : fournir `S3_CA_BUNDLE` (ou `S3_VERIFY_SSL=false` en dernier recours) sinon les opérations S3 échoueront.
- Les exports historiques restés sur HDFS continuent d'être lus/supprimés via HDFS : garder `STORAGE_PROVIDERS` configuré tant que ces exports existent.