### PR TITLE
fix(cohort): watchdog for stuck DatedMeasures

### DIFF
--- a/admin_cohort/services/prometheus_metrics.py
+++ b/admin_cohort/services/prometheus_metrics.py
@@ -18,6 +18,12 @@ QUERY_EXECUTOR_REQUEST_DURATION_SECONDS = Histogram(
     buckets=(1, 5, 10, 30, 60, 120, 300, 600, 1200, 1800, 3600, 7200, 10800, 14400, 21600),
 )
 
+STUCK_DATED_MEASURES_MARKED_FAILED = Counter(
+    "cohort360_stuck_dated_measures_marked_failed_total",
+    "DatedMeasures forced to `failed` by the watchdog, by the status they were stuck at",
+    labelnames=("stuck_status",),
+)
+
 _ACTIVE_STATUSES = [s.value for s in JobStatus if not s.is_end_state and s != JobStatus.denied]
 
 

--- a/admin_cohort/settings.py
+++ b/admin_cohort/settings.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import environ
 import pytz
 from celery.schedules import crontab
+from django.core.exceptions import ImproperlyConfigured
 from django.db.utils import DEFAULT_DB_ALIAS
 
 
@@ -273,6 +274,11 @@ CELERY_TASK_ALWAYS_EAGER = False
 CELERY_BEAT_SCHEDULER = "django_celery_beat.schedulers:DatabaseScheduler"
 DM_WATCHDOG_PERIOD_MINUTES = env.int("DM_WATCHDOG_PERIOD_MINUTES", default=5)
 DM_WATCHDOG_THRESHOLD_MINUTES = env.int("DM_WATCHDOG_THRESHOLD_MINUTES", default=15)
+
+if DM_WATCHDOG_PERIOD_MINUTES < 1:
+    raise ImproperlyConfigured("DM_WATCHDOG_PERIOD_MINUTES must be >= 1")
+if DM_WATCHDOG_THRESHOLD_MINUTES < 1:
+    raise ImproperlyConfigured("DM_WATCHDOG_THRESHOLD_MINUTES must be >= 1")
 
 CELERY_BEAT_SCHEDULE = {
     "maintenance_notifier": {

--- a/admin_cohort/settings.py
+++ b/admin_cohort/settings.py
@@ -271,11 +271,18 @@ CELERY_RESULT_SERIALIZER = "json"
 CELERY_TASK_SERIALIZER = "json"
 CELERY_TASK_ALWAYS_EAGER = False
 CELERY_BEAT_SCHEDULER = "django_celery_beat.schedulers:DatabaseScheduler"
+DM_WATCHDOG_PERIOD_MINUTES = env.int("DM_WATCHDOG_PERIOD_MINUTES", default=5)
+DM_WATCHDOG_THRESHOLD_MINUTES = env.int("DM_WATCHDOG_THRESHOLD_MINUTES", default=15)
+
 CELERY_BEAT_SCHEDULE = {
     "maintenance_notifier": {
         "task": "admin_cohort.tasks.maintenance_notifier_checker",
         "schedule": crontab(minute=f"*/{MAINTENANCE_PERIODIC_SCHEDULING_MINUTES}"),
-    }
+    },
+    "mark_stuck_dated_measures_as_failed": {
+        "task": "cohort.tasks.mark_stuck_dated_measures_as_failed",
+        "schedule": crontab(minute=f"*/{DM_WATCHDOG_PERIOD_MINUTES}"),
+    },
 }
 
 SCHEDULED_TASKS = env("SCHEDULED_TASKS", default="")

--- a/cohort/tasks.py
+++ b/cohort/tasks.py
@@ -1,9 +1,13 @@
 import logging
+from datetime import timedelta
 from typing import Optional
 
 from celery import shared_task, current_task
+from django.conf import settings
+from django.utils import timezone
 
 from admin_cohort import celery_app
+from admin_cohort.services.prometheus_metrics import STUCK_DATED_MEASURES_MARKED_FAILED
 from admin_cohort.types import JobStatus
 from cohort.models import CohortResult, DatedMeasure, FeasibilityStudy, RequestQuerySnapshot
 from cohort.services.base_service import load_operator
@@ -16,6 +20,8 @@ from cohort.services.emails import (
 from cohort.services.utils import locked_instance_task, get_feasibility_study_by_id, send_email_notification, ServerError
 
 logger = logging.getLogger(__name__)
+
+STUCK_DM_NON_TERMINAL_STATUSES = (JobStatus.new, JobStatus.pending, JobStatus.started)
 
 
 @shared_task
@@ -120,6 +126,35 @@ def send_email_count_request_refreshed(snapshot_id: str) -> None:
         request_name=f"{snapshot.request.name} (version {snapshot.version})",
         owner=snapshot.owner,
     )
+
+
+@shared_task
+def mark_stuck_dated_measures_as_failed() -> int:
+    from cohort.services.dated_measure import dm_service
+
+    threshold_minutes = getattr(settings, "DM_WATCHDOG_THRESHOLD_MINUTES", 15)
+    cutoff = timezone.now() - timedelta(minutes=threshold_minutes)
+    stuck = DatedMeasure.objects.filter(
+        request_job_status__in=STUCK_DM_NON_TERMINAL_STATUSES,
+        modified_at__lt=cutoff,
+    )
+
+    count = 0
+    for dm in stuck:
+        try:
+            duration = timezone.now() - dm.created_at
+            stuck_status = dm.request_job_status
+            dm.request_job_status = JobStatus.failed
+            dm.request_job_fail_msg = f"Aucune réponse du moteur de calcul après {threshold_minutes} min."
+            dm.request_job_duration = str(duration)
+            dm.save()
+            dm_service.ws_send_to_client(dm=dm)
+            STUCK_DATED_MEASURES_MARKED_FAILED.labels(stuck_status=stuck_status).inc()
+            count += 1
+            logger.warning(f"DatedMeasure[{dm.uuid}] stuck at `{stuck_status}` → forced to `failed` (owner={dm.owner_id})")
+        except Exception as e:
+            logger.exception(f"DatedMeasure[{dm.uuid}] watchdog failed: {e}")
+    return count
 
 
 @shared_task

--- a/cohort/tasks.py
+++ b/cohort/tasks.py
@@ -144,14 +144,25 @@ def mark_stuck_dated_measures_as_failed() -> int:
         try:
             duration = timezone.now() - dm.created_at
             stuck_status = dm.request_job_status
-            dm.request_job_status = JobStatus.failed
-            dm.request_job_fail_msg = f"Aucune réponse du moteur de calcul après {threshold_minutes} min."
-            dm.request_job_duration = str(duration)
-            dm.save()
-            dm_service.ws_send_to_client(dm=dm)
+            # Compare-and-swap : ne bascule en `failed` que si la DM est toujours
+            # éligible. Évite d'écraser un statut terminal posé entre-temps par le
+            # Query Executor (ou un run watchdog concurrent).
+            updated = DatedMeasure.objects.filter(
+                pk=dm.pk,
+                request_job_status__in=STUCK_DM_NON_TERMINAL_STATUSES,
+                modified_at__lt=cutoff,
+            ).update(
+                request_job_status=JobStatus.failed,
+                request_job_fail_msg=f"Aucune réponse du moteur de calcul après {threshold_minutes} min.",
+                request_job_duration=str(duration),
+            )
+            if not updated:
+                continue
             STUCK_DATED_MEASURES_MARKED_FAILED.labels(stuck_status=stuck_status).inc()
             count += 1
             logger.warning(f"DatedMeasure[{dm.uuid}] stuck at `{stuck_status}` → forced to `failed` (owner={dm.owner_id})")
+            dm.refresh_from_db()
+            dm_service.ws_send_to_client(dm=dm)
         except Exception as e:
             logger.exception(f"DatedMeasure[{dm.uuid}] watchdog failed: {e}")
     return count

--- a/cohort/tests/tests_celery_tasks.py
+++ b/cohort/tests/tests_celery_tasks.py
@@ -209,3 +209,18 @@ class TasksTests(TestCaseWithDBs):
         self.assertEqual(finished_dm.request_job_status, JobStatus.finished.value)
         self.assertEqual(failed_dm.request_job_status, JobStatus.failed.value)
         mock_ws_send.assert_not_called()
+
+    @mock.patch("cohort.services.dated_measure.dm_service.ws_send_to_client")
+    def test_watchdog_counts_dm_even_when_ws_send_fails(self, mock_ws_send):
+        # Le WS est best-effort : une erreur d'émission ne doit pas faire diverger
+        # le statut DB (déjà `failed`) de la métrique / du compteur retourné.
+        mock_ws_send.side_effect = RuntimeError("ws down")
+        threshold = settings.DM_WATCHDOG_THRESHOLD_MINUTES
+        self._backdate(self.started_dm, minutes=threshold + 5)
+
+        marked = mark_stuck_dated_measures_as_failed()
+
+        self.assertEqual(marked, 1)
+        self.started_dm.refresh_from_db()
+        self.assertEqual(self.started_dm.request_job_status, JobStatus.failed.value)
+        mock_ws_send.assert_called_once()

--- a/cohort/tests/tests_celery_tasks.py
+++ b/cohort/tests/tests_celery_tasks.py
@@ -1,7 +1,9 @@
+from datetime import timedelta
 from unittest import mock
 from unittest.mock import MagicMock
 
 from django.conf import settings
+from django.utils import timezone
 
 from accesses.models import Perimeter
 from admin_cohort.tests.tests_tools import new_random_user, TestCaseWithDBs
@@ -19,6 +21,7 @@ from cohort.tasks import (
     create_cohort,
     cancel_previous_count_jobs,
     feasibility_study_count,
+    mark_stuck_dated_measures_as_failed,
     send_feasibility_study_notification,
     send_email_feasibility_report_ready,
     send_email_feasibility_report_error,
@@ -147,3 +150,62 @@ class TasksTests(TestCaseWithDBs):
         cancel_previous_count_jobs(dm_id=self.dm2.uuid, cohort_counter_cls=self.cohort_counter_cls)
         failed_dm = DatedMeasure.objects.exclude(uuid=self.dm2.uuid).filter(request_query_snapshot=self.req_snapshot3).first()
         self.assertEqual(failed_dm.request_job_status, JobStatus.failed.value)
+
+    def _backdate(self, dm: DatedMeasure, minutes: int) -> None:
+        past = timezone.now() - timedelta(minutes=minutes)
+        DatedMeasure.objects.filter(pk=dm.pk).update(modified_at=past, created_at=past)
+
+    @mock.patch("cohort.services.dated_measure.dm_service.ws_send_to_client")
+    def test_watchdog_marks_stuck_dms_as_failed(self, mock_ws_send):
+        threshold = settings.DM_WATCHDOG_THRESHOLD_MINUTES
+        self._backdate(self.new_dm, minutes=threshold + 5)
+        self._backdate(self.started_dm, minutes=threshold + 5)
+        self._backdate(self.pending_dm, minutes=threshold + 5)
+
+        marked = mark_stuck_dated_measures_as_failed()
+
+        self.assertEqual(marked, 3)
+        for dm in (self.new_dm, self.started_dm, self.pending_dm):
+            dm.refresh_from_db()
+            self.assertEqual(dm.request_job_status, JobStatus.failed.value)
+            self.assertIn("moteur de calcul", dm.request_job_fail_msg)
+            self.assertTrue(dm.request_job_duration)
+        self.assertEqual(mock_ws_send.call_count, 3)
+
+    @mock.patch("cohort.services.dated_measure.dm_service.ws_send_to_client")
+    def test_watchdog_ignores_recent_dms(self, mock_ws_send):
+        self._backdate(self.started_dm, minutes=1)
+        self._backdate(self.pending_dm, minutes=2)
+
+        marked = mark_stuck_dated_measures_as_failed()
+
+        self.assertEqual(marked, 0)
+        for dm in (self.started_dm, self.pending_dm):
+            dm.refresh_from_db()
+            self.assertEqual(dm.request_job_status, JobStatus.started.value if dm == self.started_dm else JobStatus.pending.value)
+        mock_ws_send.assert_not_called()
+
+    @mock.patch("cohort.services.dated_measure.dm_service.ws_send_to_client")
+    def test_watchdog_ignores_terminal_dms(self, mock_ws_send):
+        threshold = settings.DM_WATCHDOG_THRESHOLD_MINUTES
+        finished_dm = DatedMeasure.objects.create(
+            owner=self.user1,
+            request_query_snapshot=self.req_snapshot,
+            request_job_status=JobStatus.finished,
+        )
+        failed_dm = DatedMeasure.objects.create(
+            owner=self.user1,
+            request_query_snapshot=self.req_snapshot,
+            request_job_status=JobStatus.failed,
+        )
+        self._backdate(finished_dm, minutes=threshold + 60)
+        self._backdate(failed_dm, minutes=threshold + 60)
+
+        marked = mark_stuck_dated_measures_as_failed()
+
+        self.assertEqual(marked, 0)
+        finished_dm.refresh_from_db()
+        failed_dm.refresh_from_db()
+        self.assertEqual(finished_dm.request_job_status, JobStatus.finished.value)
+        self.assertEqual(failed_dm.request_job_status, JobStatus.failed.value)
+        mock_ws_send.assert_not_called()


### PR DESCRIPTION
## Objectif
Fixes https://gitlab.data.aphp.fr/ID/design-et-produit/ipa/cohort360/gestion-de-projet/-/issues/3298.

Un \`DatedMeasure\` peut rester indéfiniment en \`new\`/\`pending\`/\`started\` quand le Query Executor accepte un job mais ne PATCHe jamais de statut terminal (réseau, crash, timeout SOLR). Sans transition terminale, le WS de complétion ne part jamais et le front reste bloqué sur un spinner perpétuel.

## Changements réalisés
- Nouvelle tâche Celery beat \`mark_stuck_dated_measures_as_failed\` (\`cohort/tasks.py\`).
- Sélection des DMs \`new\`/\`pending\`/\`started\` dont \`modified_at < now - DM_WATCHDOG_THRESHOLD_MINUTES\`, bascule en \`failed\`, broadcast WS à l'owner.
- 2 settings configurables via env : \`DM_WATCHDOG_PERIOD_MINUTES\` (défaut 5), \`DM_WATCHDOG_THRESHOLD_MINUTES\` (défaut 15).
- Métrique Prometheus \`cohort360_stuck_dated_measures_marked_failed_total{stuck_status}\` pour observabilité.

## Impacts
- Jobs : nouvelle tâche périodique (5 min par défaut), requête DB indexée sur \`request_job_status\` + \`modified_at\`.
- API : aucun changement de contrat.
- Observabilité : métrique prête à scraper, panneau Grafana à ajouter à la main (pas dans ce repo).

## Tests réalisés
- 3 tests Django ajoutés (\`cohort/tests/tests_celery_tasks.py\`) : DMs stuck > seuil → failed + WS ; DMs récents ignorés ; DMs terminaux ignorés.
- mypy clean sur les fichiers touchés.

## Risques
- Seuil de 15 min : si un count SOLR légitime dure plus longtemps, il sera marqué \`failed\` à tort. À monitorer via la métrique.
- Le WS broadcasté à l'owner est sans effet si l'owner n'est pas connecté. C'est intentionnel : le front polle aussi (PR sœur côté front).

PR sœur côté front : aphp/Cohort360-FrontEnd#1260

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added a watchdog that detects stalled dated measures and automatically sets them to **failed** after a configurable threshold.
  * Sends real-time websocket updates when measures are marked failed.

* **Configuration**
  * Introduced environment-configurable Celery beat parameters to control watchdog timing and the staleness threshold.

* **Monitoring**
  * Added a Prometheus counter to track how many stuck measures are marked failed, labeled by their prior status.

* **Tests**
  * Expanded watchdog test coverage, including exclusions for recent/terminal measures and resilience when websocket notifications fail.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->