### PR TITLE
fix(exports): match required Patient table case-insensitively

### DIFF
--- a/exporters/exporters/base_exporter.py
+++ b/exporters/exporters/base_exporter.py
@@ -80,7 +80,7 @@ class BaseExporter:
     def build_tables_input(self, export) -> List[dict[str, str]]:
         required_table_name = self.export_api.required_table
         try:
-            required_table = export.export_tables.get(name=required_table_name)
+            required_table = export.export_tables.get(name__iexact=required_table_name)
             linked_cohort = required_table.cohort_result_subset or required_table.cohort_result_source
             required_table_data = {"tableName": required_table_name, "cohortId": linked_cohort.group_id, "relation": True}
             if required_table.columns:
@@ -89,7 +89,7 @@ class BaseExporter:
             raise ValueError(f"Missing {required_table_name} table from export")
 
         other_tables = []
-        for t in export.export_tables.exclude(name=required_table_name):
+        for t in export.export_tables.exclude(name__iexact=required_table_name):
             t_data = {"tableName": t.name, "relation": True}
             if t.cohort_result_subset:
                 t_data["cohortId"] = t.cohort_result_subset.group_id

--- a/exporters/exporters/hive_exporter.py
+++ b/exporters/exporters/hive_exporter.py
@@ -32,7 +32,7 @@ class HiveExporter(BaseExporter):
         for td in tables_data:
             source_cohort_id = td.get("cohort_result_source")
 
-            if td.get("table_name", "") == required_table:
+            if td.get("table_name", "").lower() == required_table.lower():
                 required_table_provided = True
                 if not source_cohort_id:
                     raise ValueError(f"The `{required_table}` table can not be exported without a source cohort")

--- a/exporters/tests/test_base_exporter.py
+++ b/exporters/tests/test_base_exporter.py
@@ -3,6 +3,7 @@ from unittest import mock
 from exporters.exporters.base_exporter import BaseExporter
 from exporters.enums import ExportTypes
 from exporters.tests.base_test import ExportersTestBase
+from exports.models import Export, ExportTable
 
 
 class TestBaseExporter(ExportersTestBase):
@@ -39,3 +40,38 @@ class TestBaseExporter(ExportersTestBase):
         self.assertIn("target_name", export_data)
         self.assertIn("target_location", export_data)
         self.assertNotIn("\n", export_data["motivation"])
+
+    def _build_datalab_export(self, patient_table_name: str) -> Export:
+        export = Export.objects.create(
+            owner=self.csv_exporter_user,
+            target_location="target_location",
+            target_name="target_name",
+            nominative=True,
+            output_format=ExportTypes.HIVE.value,
+            datalab=self.datalab,
+        )
+        ExportTable.objects.create(export=export, name=patient_table_name, cohort_result_source=self.cohort)
+        ExportTable.objects.create(export=export, name="death_date_insee", cohort_result_source=self.cohort)
+        return export
+
+    def test_send_export_succeeds_when_patient_table_capitalized(self):
+        export = self._build_datalab_export(patient_table_name="Patient")
+        with mock.patch.object(self.exporter.export_api, "launch_export", return_value="job-id") as mock_launch:
+            self.exporter.send_export(export=export, params={})
+        mock_launch.assert_called_once()
+        tables_sent = [t["tableName"] for t in mock_launch.call_args.kwargs["params"]["tablesToExport"]]
+        self.assertIn("Patient", tables_sent)
+        self.assertIn("death_date_insee", tables_sent)
+
+    def test_send_export_tolerates_lowercase_patient_table(self):
+        # Ref #3289: the AdministrationPortal used to send `table_name: 'patient'` (lowercase) while the
+        # required table is "Patient". The lookup is case-insensitive so the export still reaches the
+        # data-exporter, and the canonical "Patient" table name is forwarded regardless of stored casing.
+        export = self._build_datalab_export(patient_table_name="patient")
+        with mock.patch.object(self.exporter.export_api, "launch_export", return_value="job-id") as mock_launch:
+            self.exporter.send_export(export=export, params={})
+        mock_launch.assert_called_once()
+        tables_sent = [t["tableName"] for t in mock_launch.call_args.kwargs["params"]["tablesToExport"]]
+        self.assertIn("Patient", tables_sent)
+        self.assertNotIn("patient", tables_sent)
+        self.assertIn("death_date_insee", tables_sent)

--- a/exporters/tests/test_hive_exporter.py
+++ b/exporters/tests/test_hive_exporter.py
@@ -53,6 +53,13 @@ class TestHiveExporter(ExportersTestBase):
         with self.assertRaises(ValueError):
             self.exporter.validate_tables_data(tables_data=tables_data)
 
+    def test_validate_tables_data_detects_required_table_case_insensitively(self):
+        # Ref #3289: a lowercase `patient` table is recognized as the required table, so the
+        # "missing source cohort" rule still applies instead of being silently skipped.
+        tables_data = [{"table_name": "patient"}]
+        with self.assertRaises(ValueError):
+            self.exporter.validate_tables_data(tables_data=tables_data)
+
     def test_validate_tables_data_all_tables_without_source_cohort_nor_person_table(self):
         # tables data is not valid if the `Patient` table has no source cohort
         tables_data = [{"table_name": "table_01"}, {"table_name": "table_02"}]


### PR DESCRIPTION
## Objectif
Fixes https://gitlab.data.aphp.fr/ID/design-et-produit/ipa/cohort360/gestion-de-projet/-/work_items/3289

Le transfert Datalab n'atteignait jamais le data-exporter quand la table patient n'avait pas la casse attendue (`patient` au lieu de `Patient`) : le lookup échouait avant le lancement.

## Changements réalisés
Lookup de la table requise en `name__iexact` au lieu d'une égalité stricte.

## Impacts
Back / exports Datalab.

## Tests réalisés
Unitaires (casse correcte + tolérée). Suites `exporters` + `exports` OK.

## Risques
Aucun si la casse est déjà correcte.