### PR TITLE
fix(requests): order requests with null updated_at last

### DIFF
--- a/admin_cohort/tools/ordering.py
+++ b/admin_cohort/tools/ordering.py
@@ -1,0 +1,21 @@
+from django.core.validators import EMPTY_VALUES
+from django.db.models import F
+from django_filters import OrderingFilter
+
+
+class NullsLastOrderingFilter(OrderingFilter):
+    # Postgres orders NULLs first on a descending sort by default.
+
+    def filter(self, qs, value):
+        if value in EMPTY_VALUES:
+            return qs
+
+        ordering = []
+        for param in value:
+            if param in EMPTY_VALUES:
+                continue
+            field_name = self.get_ordering_value(param)
+            descending = field_name.startswith("-")
+            expression = F(field_name[1:] if descending else field_name)
+            ordering.append(expression.desc(nulls_last=True) if descending else expression.asc(nulls_last=True))
+        return qs.order_by(*ordering)

--- a/cohort/tests/tests_view_requests.py
+++ b/cohort/tests/tests_view_requests.py
@@ -8,7 +8,7 @@ from rest_framework.test import force_authenticate
 
 from admin_cohort.models import User
 from admin_cohort.tests.tests_tools import CaseRetrieveFilter, random_str, ListCase, RetrieveCase, CreateCase, DeleteCase, PatchCase, RequestCase
-from cohort.models import Request, Folder
+from cohort.models import Request, Folder, RequestQuerySnapshot
 from cohort.tests.cohort_app_tests import CohortAppTests
 from cohort.tests.tests_view_folders import FolderCaseRetrieveFilter
 from cohort.views import RequestViewSet, NestedRequestViewSet
@@ -126,6 +126,28 @@ class RequestsGetTests(RequestsTests):
             ),
         ]
         [self.check_get_paged_list_case(case) for case in cases]
+
+    def test_list_ordering_puts_null_updated_at_last(self):
+        # As a user, when ordering by updated_at, requests without snapshots (null updated_at)
+        # must come last instead of bubbling to the top on a descending sort
+        folder = Folder.objects.create(owner=self.user1, name="ordering")
+        older = Request.objects.create(name="older", owner=self.user1, parent_folder=folder)
+        newer = Request.objects.create(name="newer", owner=self.user1, parent_folder=folder)
+        no_snapshot = Request.objects.create(name="no_snapshot", owner=self.user1, parent_folder=folder)
+
+        now = timezone.now()
+        for req, days in ((older, 2), (newer, 1)):
+            snapshot = RequestQuerySnapshot.objects.create(owner=self.user1, request=req, serialized_query="{}")
+            RequestQuerySnapshot.objects.filter(pk=snapshot.pk).update(created_at=now - timedelta(days=days))
+
+        request = self.factory.get(self.objects_url, data=dict(parent_folder=folder.pk, ordering="-updated_at"))
+        force_authenticate(request, self.user1)
+        response = self.__class__.list_view(request)
+        response.render()
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        ordered_ids = [r["uuid"] for r in response.data["results"]]
+        self.assertEqual(ordered_ids, [str(newer.pk), str(older.pk), str(no_snapshot.pk)])
 
     def test_rest_get_list_from_folder(self):
         # As a user, I can get the list of requests from the Folder they are

--- a/cohort/views/request.py
+++ b/cohort/views/request.py
@@ -1,12 +1,13 @@
 from django.db.models.expressions import Subquery, OuterRef
 from django.db.models.query import Prefetch
 from django.http import QueryDict
-from django_filters import rest_framework as filters, OrderingFilter
+from django_filters import rest_framework as filters
 from drf_spectacular.utils import extend_schema_view, extend_schema
 from rest_framework import status
 from rest_framework_extensions.mixins import NestedViewSetMixin
 
 from admin_cohort.tools.cache import cache_response
+from admin_cohort.tools.ordering import NullsLastOrderingFilter
 from cohort.models import Request, RequestQuerySnapshot as RQS
 from cohort.serializers import RequestSerializer, RequestCreateSerializer, RequestPatchSerializer
 from cohort.views.shared import UserObjectsRestrictedViewSet
@@ -16,7 +17,7 @@ class RequestFilter(filters.FilterSet):
     min_updated_at = filters.IsoDateTimeFilter(field_name="updated_at", lookup_expr="gte")
     max_updated_at = filters.IsoDateTimeFilter(field_name="updated_at", lookup_expr="lte")
 
-    ordering = OrderingFilter(fields=("name", "updated_at", ("parent_folder__name", "parent_folder")))
+    ordering = NullsLastOrderingFilter(fields=("name", "updated_at", ("parent_folder__name", "parent_folder")))
 
     class Meta:
         model = Request


### PR DESCRIPTION
## Objectif
Fixes https://gitlab.data.aphp.fr/ID/design-et-produit/ipa/cohort360/gestion-de-projet/-/work_items/3095

Sur `GET /cohort/requests/?ordering=-updated_at`, les requêtes sans snapshot remontaient en tête de liste au lieu d'être reléguées en fin.

## Changements réalisés
`updated_at` est une annotation `Subquery` (`created_at` du dernier snapshot), donc `null` pour une requête sans snapshot. En tri descendant, Postgres place les `NULL` en premier par défaut.

- Ajout de `NullsLastOrderingFilter` (`admin_cohort/tools/ordering.py`) : `OrderingFilter` qui force `nulls_last` quel que soit le sens de tri, via des expressions `F(...).desc/asc(nulls_last=True)`.
- `RequestFilter` utilise ce filtre à la place de `OrderingFilter`.

## Impacts
Tri concerné (iso comportement sinon)

## Tests réalisés
- Test unitaires

## Risques
Faible. Le filtre est isolé et n'est branché que sur la vue requests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Request lists now sort items with missing dates last when ordering by newest or oldest updates.
  * Ordering behavior is now more consistent across fields, including nested folder sorting.

* **Bug Fixes**
  * Fixed cases where entries without update timestamps could appear in the wrong position during ordered listings.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->