### PR TITLE
fix(exports): set datalab ownership before reporting export success

### DIFF
--- a/exporters/exporters/base_exporter.py
+++ b/exporters/exporters/base_exporter.py
@@ -75,7 +75,25 @@ class BaseExporter:
         export.request_job_duration = str(timezone.now() - start_time)
         export.save()
         self.log_export_task(export.pk, "Export job finished")
+        # Post-export finalization (e.g. transferring file ownership to the datalab) MUST succeed
+        # before the export is reported as successful. Running it here - and not after the success
+        # notification - guarantees the exported files carry the right permissions by the time the
+        # user is told the export is ready.
+        try:
+            self.finalize_export(export=export)
+        except RequestException as e:
+            self.mark_export_as_failed(export=export, reason=f"Could not finalize export: {e}")
+            return
         self.confirm_export_succeeded(export=export)
+
+    def finalize_export(self, export: Export) -> None:
+        """Hook for post-export steps that must complete before the export is considered a success.
+
+        The default export has nothing to finalize. Subclasses (e.g. Hive) override this to transfer
+        ownership of the exported files to the target datalab; raising from here marks the export as
+        failed instead of silently leaving the files unreadable.
+        """
+        pass
 
     def build_tables_input(self, export) -> List[dict[str, str]]:
         required_table_name = self.export_api.required_table
@@ -157,7 +175,12 @@ class BaseExporter:
     @staticmethod
     def confirm_export_succeeded(export: Export) -> None:
         EXPORTS_TOTAL.labels(status=JobStatus.finished.value, output_format=export.output_format).inc()
-        notify_export_succeeded.delay(export.pk)
+        try:
+            notify_export_succeeded.delay(export.pk)
+        except Exception as e:
+            # The export and its file permissions are already complete at this point; a failure to
+            # enqueue the success notification must not bubble up and abort the task.
+            logger.error(f"[Export {export.pk}] Could not enqueue success notification: {e}")
 
     @staticmethod
     def mark_export_as_failed(export: Export, reason: str) -> None:

--- a/exporters/exporters/hive_exporter.py
+++ b/exporters/exporters/hive_exporter.py
@@ -64,10 +64,14 @@ class HiveExporter(BaseExporter):
         else:
             params = params or {"output": {"type": self.type, "databaseName": export.target_name}}
             logger.info(f"Export[{export.pk}] Calling parent handle_export with params: {params}")
+            # The parent runs the export job and then calls finalize_export() (overridden below) to
+            # transfer ownership to the datalab before the export is reported as successful.
             super().handle_export(export=export, params=params)
-            logger.info(f"Export[{export.pk}] Concluding export...")
-            self.conclude_export(export=export)
             logger.info(f"Export[{export.pk}] Hive export process finished")
+
+    def finalize_export(self, export: Export) -> None:
+        logger.info(f"Export[{export.pk}] Concluding export...")
+        self.conclude_export(export=export)
 
     def prepare_db(self, export: Export) -> None:
         logger.info(f"Export[{export.pk}] prepare_db: Creating database")
@@ -107,9 +111,9 @@ class HiveExporter(BaseExporter):
             raise RequestException(f"Error granting `{db_user}` rights on DB `{export.target_name}` - {e}")
 
     def conclude_export(self, export: Export) -> None:
+        # Transfers ownership of the exported DB files to the datalab's unix account. Any failure
+        # propagates so the caller (finalize_export -> base handle_export) marks the export as failed
+        # instead of leaving the files owned by the technical Hive user and unreadable by the datalab.
         db_user = export.datalab.name
-        try:
-            self.change_db_ownership(export=export, db_user=db_user)
-            self.log_export_task(export.pk, f"Export concluded: DB '{export.target_name}' attributed to {db_user}.")
-        except RequestException as e:
-            self.mark_export_as_failed(export=export, reason=f"Could not conclude export: {e}")
+        self.change_db_ownership(export=export, db_user=db_user)
+        self.log_export_task(export.pk, f"Export concluded: DB '{export.target_name}' attributed to {db_user}.")

--- a/exporters/tests/test_base_exporter.py
+++ b/exporters/tests/test_base_exporter.py
@@ -1,5 +1,7 @@
 from unittest import mock
 
+from requests import RequestException
+
 from exporters.exporters.base_exporter import BaseExporter
 from exporters.enums import ExportTypes
 from exporters.tests.base_test import ExportersTestBase
@@ -62,6 +64,40 @@ class TestBaseExporter(ExportersTestBase):
         tables_sent = [t["tableName"] for t in mock_launch.call_args.kwargs["params"]["tablesToExport"]]
         self.assertIn("Patient", tables_sent)
         self.assertIn("death_date_insee", tables_sent)
+
+    @mock.patch.object(BaseExporter, "confirm_export_succeeded")
+    @mock.patch.object(BaseExporter, "finalize_export")
+    @mock.patch.object(BaseExporter, "wait_for_export_job")
+    @mock.patch.object(BaseExporter, "send_export", return_value="job-id")
+    def test_handle_export_finalizes_before_success(self, mock_send, mock_wait, mock_finalize, mock_succeeded):
+        # finalize_export (where file permissions are set) must run BEFORE the success notification,
+        # so the user is never told an export is ready while its files are still unreadable.
+        export = self._build_datalab_export(patient_table_name="Patient")
+        manager = mock.Mock()
+        manager.attach_mock(mock_finalize, "finalize")
+        manager.attach_mock(mock_succeeded, "succeeded")
+
+        self.exporter.handle_export(export=export, params={})
+
+        mock_finalize.assert_called_once_with(export=export)
+        mock_succeeded.assert_called_once_with(export=export)
+        self.assertEqual([call[0] for call in manager.mock_calls], ["finalize", "succeeded"])
+
+    @mock.patch.object(BaseExporter, "mark_export_as_failed")
+    @mock.patch.object(BaseExporter, "confirm_export_succeeded")
+    @mock.patch.object(BaseExporter, "finalize_export", side_effect=RequestException("chown failed"))
+    @mock.patch.object(BaseExporter, "wait_for_export_job")
+    @mock.patch.object(BaseExporter, "send_export", return_value="job-id")
+    def test_handle_export_marks_failed_when_finalize_fails(self, mock_send, mock_wait, mock_finalize, mock_succeeded, mock_failed):
+        # A failure to finalize (e.g. the ownership transfer) must mark the export as failed and never
+        # report success.
+        export = self._build_datalab_export(patient_table_name="Patient")
+
+        self.exporter.handle_export(export=export, params={})
+
+        mock_finalize.assert_called_once_with(export=export)
+        mock_failed.assert_called_once()
+        mock_succeeded.assert_not_called()
 
     def test_send_export_tolerates_lowercase_patient_table(self):
         # Ref #3289: the AdministrationPortal used to send `table_name: 'patient'` (lowercase) while the

--- a/exporters/tests/test_hive_exporter.py
+++ b/exporters/tests/test_hive_exporter.py
@@ -95,11 +95,12 @@ class TestHiveExporter(ExportersTestBase):
         self.exporter.conclude_export(export=self.hive_export)
         self.mock_hadoop_api.change_db_ownership.assert_called_once()
 
-    @mock.patch("exporters.exporters.base_exporter.notify_export_failed.delay")
-    def test_error_conclude_export(self, mock_notify_export_failed):
+    def test_error_conclude_export(self):
+        # conclude_export must propagate the failure so the caller marks the export as failed
+        # instead of silently leaving the files unreadable by the datalab.
         self.mock_hadoop_api.change_db_ownership.side_effect = RequestException()
-        self.exporter.conclude_export(export=self.hive_export)
-        mock_notify_export_failed.assert_called_once()
+        with self.assertRaises(RequestException):
+            self.exporter.conclude_export(export=self.hive_export)
 
     def test_prepare_db(self):
         self.mock_hadoop_api.create_db.return_value = "some-job-id"
@@ -108,15 +109,20 @@ class TestHiveExporter(ExportersTestBase):
         self.mock_hadoop_api.create_db.assert_called_once()
         self.mock_hadoop_api.change_db_ownership.assert_called_once()
 
-    @mock.patch.object(HiveExporter, "conclude_export")
     @mock.patch("exporters.exporters.base_exporter.BaseExporter.handle_export")
     @mock.patch.object(HiveExporter, "prepare_db")
     @mock.patch.object(HiveExporter, "confirm_export_received")
-    def test_handle_export_success(self, mock_confirm, mock_prepare, mock_super_handle, mock_conclude):
+    def test_handle_export_success(self, mock_confirm, mock_prepare, mock_super_handle):
         self.exporter.handle_export(export=self.hive_export)
         mock_confirm.assert_called_once_with(export=self.hive_export)
         mock_prepare.assert_called_once_with(self.hive_export)
         mock_super_handle.assert_called_once()
+
+    @mock.patch.object(HiveExporter, "conclude_export")
+    def test_finalize_export_concludes(self, mock_conclude):
+        # The ownership transfer is wired through finalize_export, the hook the base exporter calls
+        # before reporting success.
+        self.exporter.finalize_export(export=self.hive_export)
         mock_conclude.assert_called_once_with(export=self.hive_export)
 
     @mock.patch.object(HiveExporter, "mark_export_as_failed")


### PR DESCRIPTION
## Objectif
Fixes https://gitlab.data.aphp.fr/ID/design-et-produit/ipa/cohort360/gestion-de-projet/-/work_items/3324

Sur un export Hive vers un datalab, le transfert de propriété des fichiers exportés vers le compte Unix du datalab (`conclude_export`) s'exécutait **après** la notification de succès et avalait ses propres erreurs. Résultat observé en Qualif (datalab RUPP) : fichiers restés au compte technique Hive (`Permission denied: user=rupp`) alors que l'export était marqué `finished`.

## Changements réalisés
Le transfert de propriété passe désormais par un hook `finalize_export` appelé **avant** `confirm_export_succeeded`. Il propage ses erreurs : un échec marque l'export `failed` (`Could not finalize export: ...`) au lieu de réussir en silence. `conclude_export` ne masque plus l'exception. L'enqueue de la notification de succès est protégé pour qu'une erreur de broker ne fasse plus échouer la tâche une fois les droits posés.

## Impacts
Back / exports. Exports CSV/XLSX inchangés (hook `finalize_export` no-op par défaut).

## Tests réalisés
Unitaires (exporters) : `conclude_export` propage l'échec ; `finalize_export` exécuté avant la notif de succès ; un échec de `finalize` marque l'export `failed` sans notif de succès. Vérification manuelle : le ré-appel du chown vers `rupp` a débloqué l'accès en Qualif.

## Risques
Cas non couvert : mort brutale du worker Celery pendant `finalize` (pas d'exception à intercepter), l'export resterait `finished` sans droits. Robustification complète = réconciliation/idempotence (nécessite un endpoint `get owner` côté API Hadoop, hors scope).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Export completion now waits for all post-export steps to finish before showing success.
  * If a post-export step fails, the export is marked failed and success is not confirmed.
  * Success notifications now fail safely, with errors logged instead of interrupting the export flow.
  * Hive export ownership changes now surface failures properly, improving error handling during export finalization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->