### PR TITLE
feat(users): persist onboarding progress and expose me/onboarding

### DIFF
--- a/admin_cohort/migrations/0011_user_onboarding.py
+++ b/admin_cohort/migrations/0011_user_onboarding.py
@@ -7,7 +7,7 @@ ONBOARDING_TOTAL_STEPS = 3
 
 
 def mark_existing_users_onboarded(apps, schema_editor):
-    User = apps.get_model('admin_cohort', 'User')
+    User = apps.get_model("admin_cohort", "User")
     db_alias = schema_editor.connection.alias
     User.objects.using(db_alias).filter(onboarding_completed_at__isnull=True, delete_datetime__isnull=True).update(
         onboarding_step=ONBOARDING_TOTAL_STEPS,
@@ -16,20 +16,19 @@ def mark_existing_users_onboarded(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
-        ('admin_cohort', '0010_maintenancephase_is_data_saved_message_hidden'),
+        ("admin_cohort", "0010_maintenancephase_is_data_saved_message_hidden"),
     ]
 
     operations = [
         migrations.AddField(
-            model_name='user',
-            name='onboarding_step',
+            model_name="user",
+            name="onboarding_step",
             field=models.PositiveSmallIntegerField(default=0),
         ),
         migrations.AddField(
-            model_name='user',
-            name='onboarding_completed_at',
+            model_name="user",
+            name="onboarding_completed_at",
             field=models.DateTimeField(blank=True, null=True),
         ),
         migrations.RunPython(

--- a/admin_cohort/migrations/0011_user_onboarding.py
+++ b/admin_cohort/migrations/0011_user_onboarding.py
@@ -1,0 +1,39 @@
+from django.db import migrations, models
+from django.utils import timezone
+
+# Number of macro steps in the onboarding journey at the time of this migration.
+# Kept literal so the migration stays independent from the model code.
+ONBOARDING_TOTAL_STEPS = 3
+
+
+def mark_existing_users_onboarded(apps, schema_editor):
+    User = apps.get_model('admin_cohort', 'User')
+    db_alias = schema_editor.connection.alias
+    User.objects.using(db_alias).filter(onboarding_completed_at__isnull=True, delete_datetime__isnull=True).update(
+        onboarding_step=ONBOARDING_TOTAL_STEPS,
+        onboarding_completed_at=timezone.now(),
+    )
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('admin_cohort', '0010_maintenancephase_is_data_saved_message_hidden'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='user',
+            name='onboarding_step',
+            field=models.PositiveSmallIntegerField(default=0),
+        ),
+        migrations.AddField(
+            model_name='user',
+            name='onboarding_completed_at',
+            field=models.DateTimeField(blank=True, null=True),
+        ),
+        migrations.RunPython(
+            code=mark_existing_users_onboarded,
+            reverse_code=migrations.RunPython.noop,
+        ),
+    ]

--- a/admin_cohort/models/user.py
+++ b/admin_cohort/models/user.py
@@ -5,6 +5,8 @@ from admin_cohort.models import BaseModel
 
 
 class User(AbstractBaseUser, BaseModel):
+    ONBOARDING_TOTAL_STEPS = 3
+
     USERNAME_FIELD = "username"
     username = models.CharField(unique=True, primary_key=True, null=False, max_length=30)  # type: ignore[assignment]
     email = models.EmailField("email address", max_length=254, unique=True, null=True)
@@ -13,6 +15,8 @@ class User(AbstractBaseUser, BaseModel):
     password = models.CharField(blank=True, null=True, max_length=128)  # type: ignore[assignment]
     created_by = models.ForeignKey("self", on_delete=models.SET_NULL, related_name="created_users", null=True, blank=True, db_column="created_by")
     updated_by = models.ForeignKey("self", on_delete=models.SET_NULL, related_name="updated_users", null=True, blank=True, db_column="updated_by")
+    onboarding_step = models.PositiveSmallIntegerField(default=0)
+    onboarding_completed_at = models.DateTimeField(blank=True, null=True)
 
     def __str__(self):
         return f"{self.firstname} {self.lastname} ({self.username})"

--- a/admin_cohort/serializers.py
+++ b/admin_cohort/serializers.py
@@ -1,3 +1,4 @@
+from django.utils import timezone
 from rest_framework import serializers
 from rest_framework.exceptions import ValidationError
 from rest_framework_tracking.models import APIRequestLog
@@ -52,10 +53,37 @@ class UserSerializer(serializers.ModelSerializer):
     password = serializers.CharField(write_only=True, required=False)
     created_by: serializers.SlugRelatedField = serializers.SlugRelatedField(read_only=True, slug_field="display_name")
     updated_by: serializers.SlugRelatedField = serializers.SlugRelatedField(read_only=True, slug_field="display_name")
+    onboarding_step = serializers.IntegerField(read_only=True)
+    onboarding_completed_at = serializers.DateTimeField(read_only=True)
 
     class Meta:
         model = User
-        fields = ["username", "firstname", "lastname", "email", "password", "display_name", "created_by", "updated_by"]
+        fields = ["username", "firstname", "lastname", "email", "password", "display_name", "created_by", "updated_by",
+                  "onboarding_step", "onboarding_completed_at"]
+
+
+class OnboardingSerializer(serializers.ModelSerializer):
+    onboarding_step = serializers.IntegerField(min_value=0, max_value=User.ONBOARDING_TOTAL_STEPS)
+
+    class Meta:
+        model = User
+        fields = ["onboarding_step", "onboarding_completed_at"]
+        read_only_fields = ["onboarding_completed_at"]
+
+    def validate_onboarding_step(self, value):
+        current = self.instance.onboarding_step if self.instance else 0
+        if value < current:
+            raise ValidationError("onboarding_step cannot decrease")
+        if value > current + 1:
+            raise ValidationError("onboarding_step must progress one step at a time")
+        return value
+
+    def update(self, instance, validated_data):
+        instance.onboarding_step = validated_data["onboarding_step"]
+        if instance.onboarding_step >= User.ONBOARDING_TOTAL_STEPS and instance.onboarding_completed_at is None:
+            instance.onboarding_completed_at = timezone.now()
+        instance.save(update_fields=["onboarding_step", "onboarding_completed_at", "update_datetime"])
+        return instance
 
 
 class UserCreateSerializer(serializers.ModelSerializer):

--- a/admin_cohort/serializers.py
+++ b/admin_cohort/serializers.py
@@ -58,8 +58,18 @@ class UserSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = User
-        fields = ["username", "firstname", "lastname", "email", "password", "display_name", "created_by", "updated_by",
-                  "onboarding_step", "onboarding_completed_at"]
+        fields = [
+            "username",
+            "firstname",
+            "lastname",
+            "email",
+            "password",
+            "display_name",
+            "created_by",
+            "updated_by",
+            "onboarding_step",
+            "onboarding_completed_at",
+        ]
 
 
 class OnboardingSerializer(serializers.ModelSerializer):
@@ -82,7 +92,11 @@ class OnboardingSerializer(serializers.ModelSerializer):
         instance.onboarding_step = validated_data["onboarding_step"]
         if instance.onboarding_step >= User.ONBOARDING_TOTAL_STEPS and instance.onboarding_completed_at is None:
             instance.onboarding_completed_at = timezone.now()
-        instance.save(update_fields=["onboarding_step", "onboarding_completed_at", "update_datetime"])
+        update_fields = ["onboarding_step", "onboarding_completed_at", "update_datetime"]
+        if "updated_by" in validated_data:
+            instance.updated_by = validated_data["updated_by"]
+            update_fields.append("updated_by")
+        instance.save(update_fields=update_fields)
         return instance
 
 

--- a/admin_cohort/tests/tests_view_user.py
+++ b/admin_cohort/tests/tests_view_user.py
@@ -4,7 +4,7 @@ from unittest import mock
 from django.utils import timezone
 from django.conf import settings
 from rest_framework import status
-from rest_framework.test import force_authenticate
+from rest_framework.test import APIClient, force_authenticate
 
 from accesses.models import Access, Role, Perimeter, Profile
 from admin_cohort.exceptions import ServerError
@@ -226,3 +226,89 @@ class UserTestsAsAdmin(UserTests):
         response = UserViewSet.as_view({"get": "check_user_exists"})(request, username=random_username)
         response.render()
         self.assertEqual(response.status_code, status.HTTP_500_INTERNAL_SERVER_ERROR)
+
+    def test_user_serializer_exposes_onboarding_fields(self):
+        request = self.factory.get(USERS_URL)
+        force_authenticate(request, self.admin_user)
+        response = UserViewSet.as_view({"get": "retrieve"})(request, username=self.user1.username)
+        response.render()
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
+        payload = self.get_response_payload(response)
+        self.assertIn("onboarding_step", payload)
+        self.assertIn("onboarding_completed_at", payload)
+
+
+ONBOARDING_URL = f"{USERS_URL}/me/onboarding"
+
+
+class UserOnboardingTests(UserTests):
+    onboarding_view = UserViewSet.as_view({"patch": "update_onboarding"})
+
+    def _patch_onboarding(self, user, data):
+        request = self.factory.patch(ONBOARDING_URL, data, format="json")
+        force_authenticate(request, user)
+        response = self.onboarding_view(request)
+        response.render()
+        return response
+
+    def test_advance_onboarding_step(self):
+        # user3 has no admin rights: this proves the endpoint is self-scoped, not gated by UsersPermission
+        response = self._patch_onboarding(self.user3, dict(onboarding_step=1))
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
+        self.user3.refresh_from_db()
+        self.assertEqual(self.user3.onboarding_step, 1)
+        self.assertIsNone(self.user3.onboarding_completed_at)
+
+    def test_completing_last_step_sets_completed_at(self):
+        response = self._patch_onboarding(self.user1, dict(onboarding_step=User.ONBOARDING_TOTAL_STEPS))
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
+        self.user1.refresh_from_db()
+        self.assertEqual(self.user1.onboarding_step, User.ONBOARDING_TOTAL_STEPS)
+        self.assertIsNotNone(self.user1.onboarding_completed_at)
+
+    def test_completed_at_is_not_overwritten(self):
+        self._patch_onboarding(self.user1, dict(onboarding_step=User.ONBOARDING_TOTAL_STEPS))
+        self.user1.refresh_from_db()
+        first_completion = self.user1.onboarding_completed_at
+        self._patch_onboarding(self.user1, dict(onboarding_step=User.ONBOARDING_TOTAL_STEPS))
+        self.user1.refresh_from_db()
+        self.assertEqual(self.user1.onboarding_completed_at, first_completion)
+
+    def test_onboarding_is_self_scoped(self):
+        # patching as user1 must never touch another user's onboarding
+        self._patch_onboarding(self.user1, dict(onboarding_step=2))
+        self.user2.refresh_from_db()
+        self.assertEqual(self.user2.onboarding_step, 0)
+        self.assertIsNone(self.user2.onboarding_completed_at)
+
+    def test_step_cannot_decrease(self):
+        self._patch_onboarding(self.user1, dict(onboarding_step=2))
+        response = self._patch_onboarding(self.user1, dict(onboarding_step=1))
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST, response.content)
+        self.user1.refresh_from_db()
+        self.assertEqual(self.user1.onboarding_step, 2)
+
+    def test_step_out_of_range_rejected(self):
+        response = self._patch_onboarding(self.user1, dict(onboarding_step=User.ONBOARDING_TOTAL_STEPS + 1))
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST, response.content)
+        self.user1.refresh_from_db()
+        self.assertEqual(self.user1.onboarding_step, 0)
+
+    def test_step_cannot_skip_ahead(self):
+        # navigation is linear (RG3305.02): a step can only progress one at a time
+        response = self._patch_onboarding(self.user1, dict(onboarding_step=2))
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST, response.content)
+        self.user1.refresh_from_db()
+        self.assertEqual(self.user1.onboarding_step, 0)
+
+    def test_route_resolves_through_router(self):
+        client = APIClient()
+        client.force_authenticate(self.user1)
+        response = client.patch("/users/me/onboarding/", dict(onboarding_step=1), format="json")
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
+
+    def test_requires_authentication(self):
+        request = self.factory.patch(ONBOARDING_URL, dict(onboarding_step=1), format="json")
+        response = self.onboarding_view(request)
+        response.render()
+        self.assertIn(response.status_code, (status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN))

--- a/admin_cohort/tests/tests_view_user.py
+++ b/admin_cohort/tests/tests_view_user.py
@@ -242,13 +242,21 @@ ONBOARDING_URL = f"{USERS_URL}/me/onboarding"
 
 
 class UserOnboardingTests(UserTests):
-    onboarding_view = UserViewSet.as_view({"patch": "update_onboarding"})
+    onboarding_view = staticmethod(UserViewSet.as_view({"patch": "update_onboarding"}))
 
     def _patch_onboarding(self, user, data):
         request = self.factory.patch(ONBOARDING_URL, data, format="json")
         force_authenticate(request, user)
         response = self.onboarding_view(request)
         response.render()
+        return response
+
+    def _advance_to_step(self, user, target):
+        # steps are linear (current + 1 only), so reach `target` one step at a time
+        user.refresh_from_db()
+        response = None
+        for step in range(user.onboarding_step + 1, target + 1):
+            response = self._patch_onboarding(user, dict(onboarding_step=step))
         return response
 
     def test_advance_onboarding_step(self):
@@ -258,16 +266,17 @@ class UserOnboardingTests(UserTests):
         self.user3.refresh_from_db()
         self.assertEqual(self.user3.onboarding_step, 1)
         self.assertIsNone(self.user3.onboarding_completed_at)
+        self.assertEqual(self.user3.updated_by_id, self.user3.username)
 
     def test_completing_last_step_sets_completed_at(self):
-        response = self._patch_onboarding(self.user1, dict(onboarding_step=User.ONBOARDING_TOTAL_STEPS))
+        response = self._advance_to_step(self.user1, User.ONBOARDING_TOTAL_STEPS)
         self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
         self.user1.refresh_from_db()
         self.assertEqual(self.user1.onboarding_step, User.ONBOARDING_TOTAL_STEPS)
         self.assertIsNotNone(self.user1.onboarding_completed_at)
 
     def test_completed_at_is_not_overwritten(self):
-        self._patch_onboarding(self.user1, dict(onboarding_step=User.ONBOARDING_TOTAL_STEPS))
+        self._advance_to_step(self.user1, User.ONBOARDING_TOTAL_STEPS)
         self.user1.refresh_from_db()
         first_completion = self.user1.onboarding_completed_at
         self._patch_onboarding(self.user1, dict(onboarding_step=User.ONBOARDING_TOTAL_STEPS))
@@ -276,13 +285,13 @@ class UserOnboardingTests(UserTests):
 
     def test_onboarding_is_self_scoped(self):
         # patching as user1 must never touch another user's onboarding
-        self._patch_onboarding(self.user1, dict(onboarding_step=2))
+        self._advance_to_step(self.user1, 2)
         self.user2.refresh_from_db()
         self.assertEqual(self.user2.onboarding_step, 0)
         self.assertIsNone(self.user2.onboarding_completed_at)
 
     def test_step_cannot_decrease(self):
-        self._patch_onboarding(self.user1, dict(onboarding_step=2))
+        self._advance_to_step(self.user1, 2)
         response = self._patch_onboarding(self.user1, dict(onboarding_step=1))
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST, response.content)
         self.user1.refresh_from_db()

--- a/admin_cohort/tests/tests_view_user.py
+++ b/admin_cohort/tests/tests_view_user.py
@@ -238,18 +238,15 @@ class UserTestsAsAdmin(UserTests):
         self.assertIn("onboarding_completed_at", payload)
 
 
-ONBOARDING_URL = f"{USERS_URL}/me/onboarding"
+ONBOARDING_URL = "/users/me/onboarding/"
 
 
 class UserOnboardingTests(UserTests):
-    onboarding_view = staticmethod(UserViewSet.as_view({"patch": "update_onboarding"}))
-
     def _patch_onboarding(self, user, data):
-        request = self.factory.patch(ONBOARDING_URL, data, format="json")
-        force_authenticate(request, user)
-        response = self.onboarding_view(request)
-        response.render()
-        return response
+        # go through the router so the action's permission_classes (IsAuthenticated) apply
+        client = APIClient()
+        client.force_authenticate(user)
+        return client.patch(ONBOARDING_URL, data, format="json")
 
     def _advance_to_step(self, user, target):
         # steps are linear (current + 1 only), so reach `target` one step at a time
@@ -310,14 +307,7 @@ class UserOnboardingTests(UserTests):
         self.user1.refresh_from_db()
         self.assertEqual(self.user1.onboarding_step, 0)
 
-    def test_route_resolves_through_router(self):
-        client = APIClient()
-        client.force_authenticate(self.user1)
-        response = client.patch("/users/me/onboarding/", dict(onboarding_step=1), format="json")
-        self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
-
     def test_requires_authentication(self):
-        request = self.factory.patch(ONBOARDING_URL, dict(onboarding_step=1), format="json")
-        response = self.onboarding_view(request)
-        response.render()
+        client = APIClient()
+        response = client.patch(ONBOARDING_URL, dict(onboarding_step=1), format="json")
         self.assertIn(response.status_code, (status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN))

--- a/admin_cohort/views/users.py
+++ b/admin_cohort/views/users.py
@@ -9,11 +9,12 @@ from django_filters import rest_framework as filters, OrderingFilter
 from drf_spectacular.utils import extend_schema, extend_schema_view
 from rest_framework import status, viewsets
 from rest_framework.decorators import action
+from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 
 from admin_cohort.models import User
 from admin_cohort.permissions import UsersPermission
-from admin_cohort.serializers import UserSerializer, UserCheckSerializer
+from admin_cohort.serializers import UserSerializer, UserCheckSerializer, OnboardingSerializer
 from admin_cohort.services.users import users_service
 from admin_cohort.tools.cache import cache_response
 from admin_cohort.exceptions import ServerError
@@ -122,3 +123,11 @@ class UserViewSet(RequestLogMixin, viewsets.ModelViewSet):
             }
             return Response(data=UserCheckSerializer(res).data, status=status.HTTP_200_OK)
         return Response(data={"message": "User not found"}, status=status.HTTP_404_NOT_FOUND)
+
+    @extend_schema(tags=["Users"], request=OnboardingSerializer, responses={status.HTTP_200_OK: OnboardingSerializer})
+    @action(detail=False, methods=["patch"], url_path="me/onboarding", permission_classes=[IsAuthenticated])
+    def update_onboarding(self, request, *args, **kwargs):
+        serializer = OnboardingSerializer(instance=request.user, data=request.data)
+        serializer.is_valid(raise_exception=True)
+        serializer.save()
+        return Response(data=serializer.data, status=status.HTTP_200_OK)

--- a/admin_cohort/views/users.py
+++ b/admin_cohort/views/users.py
@@ -129,5 +129,5 @@ class UserViewSet(RequestLogMixin, viewsets.ModelViewSet):
     def update_onboarding(self, request, *args, **kwargs):
         serializer = OnboardingSerializer(instance=request.user, data=request.data)
         serializer.is_valid(raise_exception=True)
-        serializer.save()
+        serializer.save(updated_by=request.user)
         return Response(data=serializer.data, status=status.HTTP_200_OK)


### PR DESCRIPTION
## Objectif
Persister la progression d'embarquement et exposer un endpoint self-service pour la faire avancer.
Fixes https://gitlab.data.aphp.fr/ID/design-et-produit/ipa/cohort360/gestion-de-projet/-/work_items/3305

## Changements réalisés
- `onboarding_step` (PositiveSmallInt) + `onboarding_completed_at` (DateTime) sur le modèle User, exposés en lecture seule via UserSerializer (donc présents dans la réponse de login).
- Endpoint `PATCH /users/me/onboarding/` self-scopé sur request.user (permission IsAuthenticated), validation linéaire du step (monotone, +1 max, borné 0–3), pose de completed_at au terminal.
- Data migration backfill : les utilisateurs existants au déploiement sont marqués onboardés (RG3305.05).

## Impacts
Back / API / DB (migration 0011, +2 colonnes sur `user`). Pas de Front. Endpoint nouveau, aucun existant modifié.

## Tests réalisés
Tests unitaires ajoutés (avance, complétion idempotente, self-scoping, anti-décrément, linéarité, hors-borne, auth requise, routing). Validés en local par `manage.py check` + compilation ; la suite Django nécessite Postgres (absent en local) et tournera en CI.

## Risques
Migration backfill sur la table `user` (update ciblé, exclut les soft-deleted). Aucun changement de comportement sur les endpoints users existants.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added onboarding progress tracking to user profiles, including current step and completion timestamp.
  * Introduced a profile endpoint to update onboarding progress step-by-step.

* **Bug Fixes**
  * Existing users are now automatically marked as onboarded when appropriate.
  * Final onboarding completion is recorded once and won’t be overwritten on later updates.

* **Tests**
  * Added coverage for onboarding progress rules, access control, and profile serialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->