### PR TITLE
feat(users): persist onboarding progress and expose me/onboarding 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,11 +4,13 @@ on:
   pull_request:
     branches:
       - develop
+      - backend-frigo
       - main
     types: [opened, synchronize, reopened, ready_for_review]
   push:
     branches:
       - develop
+      - backend-frigo
       - main
       - 'release/**'
       - 'hotfix/**'

--- a/exporters/exporters/base_exporter.py
+++ b/exporters/exporters/base_exporter.py
@@ -75,7 +75,25 @@ class BaseExporter:
         export.request_job_duration = str(timezone.now() - start_time)
         export.save()
         self.log_export_task(export.pk, "Export job finished")
+        # Post-export finalization (e.g. transferring file ownership to the datalab) MUST succeed
+        # before the export is reported as successful. Running it here - and not after the success
+        # notification - guarantees the exported files carry the right permissions by the time the
+        # user is told the export is ready.
+        try:
+            self.finalize_export(export=export)
+        except RequestException as e:
+            self.mark_export_as_failed(export=export, reason=f"Could not finalize export: {e}")
+            return
         self.confirm_export_succeeded(export=export)
+
+    def finalize_export(self, export: Export) -> None:
+        """Hook for post-export steps that must complete before the export is considered a success.
+
+        The default export has nothing to finalize. Subclasses (e.g. Hive) override this to transfer
+        ownership of the exported files to the target datalab; raising from here marks the export as
+        failed instead of silently leaving the files unreadable.
+        """
+        pass
 
     def build_tables_input(self, export) -> List[dict[str, str]]:
         required_table_name = self.export_api.required_table
@@ -157,7 +175,12 @@ class BaseExporter:
     @staticmethod
     def confirm_export_succeeded(export: Export) -> None:
         EXPORTS_TOTAL.labels(status=JobStatus.finished.value, output_format=export.output_format).inc()
-        notify_export_succeeded.delay(export.pk)
+        try:
+            notify_export_succeeded.delay(export.pk)
+        except Exception as e:
+            # The export and its file permissions are already complete at this point; a failure to
+            # enqueue the success notification must not bubble up and abort the task.
+            logger.error(f"[Export {export.pk}] Could not enqueue success notification: {e}")
 
     @staticmethod
     def mark_export_as_failed(export: Export, reason: str) -> None:

--- a/exporters/exporters/hive_exporter.py
+++ b/exporters/exporters/hive_exporter.py
@@ -64,10 +64,14 @@ class HiveExporter(BaseExporter):
         else:
             params = params or {"output": {"type": self.type, "databaseName": export.target_name}}
             logger.info(f"Export[{export.pk}] Calling parent handle_export with params: {params}")
+            # The parent runs the export job and then calls finalize_export() (overridden below) to
+            # transfer ownership to the datalab before the export is reported as successful.
             super().handle_export(export=export, params=params)
-            logger.info(f"Export[{export.pk}] Concluding export...")
-            self.conclude_export(export=export)
             logger.info(f"Export[{export.pk}] Hive export process finished")
+
+    def finalize_export(self, export: Export) -> None:
+        logger.info(f"Export[{export.pk}] Concluding export...")
+        self.conclude_export(export=export)
 
     def prepare_db(self, export: Export) -> None:
         logger.info(f"Export[{export.pk}] prepare_db: Creating database")
@@ -107,9 +111,9 @@ class HiveExporter(BaseExporter):
             raise RequestException(f"Error granting `{db_user}` rights on DB `{export.target_name}` - {e}")
 
     def conclude_export(self, export: Export) -> None:
+        # Transfers ownership of the exported DB files to the datalab's unix account. Any failure
+        # propagates so the caller (finalize_export -> base handle_export) marks the export as failed
+        # instead of leaving the files owned by the technical Hive user and unreadable by the datalab.
         db_user = export.datalab.name
-        try:
-            self.change_db_ownership(export=export, db_user=db_user)
-            self.log_export_task(export.pk, f"Export concluded: DB '{export.target_name}' attributed to {db_user}.")
-        except RequestException as e:
-            self.mark_export_as_failed(export=export, reason=f"Could not conclude export: {e}")
+        self.change_db_ownership(export=export, db_user=db_user)
+        self.log_export_task(export.pk, f"Export concluded: DB '{export.target_name}' attributed to {db_user}.")

--- a/exporters/tests/test_base_exporter.py
+++ b/exporters/tests/test_base_exporter.py
@@ -1,5 +1,7 @@
 from unittest import mock
 
+from requests import RequestException
+
 from exporters.exporters.base_exporter import BaseExporter
 from exporters.enums import ExportTypes
 from exporters.tests.base_test import ExportersTestBase
@@ -62,6 +64,40 @@ class TestBaseExporter(ExportersTestBase):
         tables_sent = [t["tableName"] for t in mock_launch.call_args.kwargs["params"]["tablesToExport"]]
         self.assertIn("Patient", tables_sent)
         self.assertIn("death_date_insee", tables_sent)
+
+    @mock.patch.object(BaseExporter, "confirm_export_succeeded")
+    @mock.patch.object(BaseExporter, "finalize_export")
+    @mock.patch.object(BaseExporter, "wait_for_export_job")
+    @mock.patch.object(BaseExporter, "send_export", return_value="job-id")
+    def test_handle_export_finalizes_before_success(self, mock_send, mock_wait, mock_finalize, mock_succeeded):
+        # finalize_export (where file permissions are set) must run BEFORE the success notification,
+        # so the user is never told an export is ready while its files are still unreadable.
+        export = self._build_datalab_export(patient_table_name="Patient")
+        manager = mock.Mock()
+        manager.attach_mock(mock_finalize, "finalize")
+        manager.attach_mock(mock_succeeded, "succeeded")
+
+        self.exporter.handle_export(export=export, params={})
+
+        mock_finalize.assert_called_once_with(export=export)
+        mock_succeeded.assert_called_once_with(export=export)
+        self.assertEqual([call[0] for call in manager.mock_calls], ["finalize", "succeeded"])
+
+    @mock.patch.object(BaseExporter, "mark_export_as_failed")
+    @mock.patch.object(BaseExporter, "confirm_export_succeeded")
+    @mock.patch.object(BaseExporter, "finalize_export", side_effect=RequestException("chown failed"))
+    @mock.patch.object(BaseExporter, "wait_for_export_job")
+    @mock.patch.object(BaseExporter, "send_export", return_value="job-id")
+    def test_handle_export_marks_failed_when_finalize_fails(self, mock_send, mock_wait, mock_finalize, mock_succeeded, mock_failed):
+        # A failure to finalize (e.g. the ownership transfer) must mark the export as failed and never
+        # report success.
+        export = self._build_datalab_export(patient_table_name="Patient")
+
+        self.exporter.handle_export(export=export, params={})
+
+        mock_finalize.assert_called_once_with(export=export)
+        mock_failed.assert_called_once()
+        mock_succeeded.assert_not_called()
 
     def test_send_export_tolerates_lowercase_patient_table(self):
         # Ref #3289: the AdministrationPortal used to send `table_name: 'patient'` (lowercase) while the

--- a/exporters/tests/test_hive_exporter.py
+++ b/exporters/tests/test_hive_exporter.py
@@ -95,11 +95,12 @@ class TestHiveExporter(ExportersTestBase):
         self.exporter.conclude_export(export=self.hive_export)
         self.mock_hadoop_api.change_db_ownership.assert_called_once()
 
-    @mock.patch("exporters.exporters.base_exporter.notify_export_failed.delay")
-    def test_error_conclude_export(self, mock_notify_export_failed):
+    def test_error_conclude_export(self):
+        # conclude_export must propagate the failure so the caller marks the export as failed
+        # instead of silently leaving the files unreadable by the datalab.
         self.mock_hadoop_api.change_db_ownership.side_effect = RequestException()
-        self.exporter.conclude_export(export=self.hive_export)
-        mock_notify_export_failed.assert_called_once()
+        with self.assertRaises(RequestException):
+            self.exporter.conclude_export(export=self.hive_export)
 
     def test_prepare_db(self):
         self.mock_hadoop_api.create_db.return_value = "some-job-id"
@@ -108,15 +109,20 @@ class TestHiveExporter(ExportersTestBase):
         self.mock_hadoop_api.create_db.assert_called_once()
         self.mock_hadoop_api.change_db_ownership.assert_called_once()
 
-    @mock.patch.object(HiveExporter, "conclude_export")
     @mock.patch("exporters.exporters.base_exporter.BaseExporter.handle_export")
     @mock.patch.object(HiveExporter, "prepare_db")
     @mock.patch.object(HiveExporter, "confirm_export_received")
-    def test_handle_export_success(self, mock_confirm, mock_prepare, mock_super_handle, mock_conclude):
+    def test_handle_export_success(self, mock_confirm, mock_prepare, mock_super_handle):
         self.exporter.handle_export(export=self.hive_export)
         mock_confirm.assert_called_once_with(export=self.hive_export)
         mock_prepare.assert_called_once_with(self.hive_export)
         mock_super_handle.assert_called_once()
+
+    @mock.patch.object(HiveExporter, "conclude_export")
+    def test_finalize_export_concludes(self, mock_conclude):
+        # The ownership transfer is wired through finalize_export, the hook the base exporter calls
+        # before reporting success.
+        self.exporter.finalize_export(export=self.hive_export)
         mock_conclude.assert_called_once_with(export=self.hive_export)
 
     @mock.patch.object(HiveExporter, "mark_export_as_failed")


### PR DESCRIPTION
## Objectif
Persister la progression d'embarquement et exposer un endpoint self-service pour la faire avancer.
Fixes https://gitlab.data.aphp.fr/ID/design-et-produit/ipa/cohort360/gestion-de-projet/-/work_items/3305

## Changements réalisés
- `onboarding_step` (PositiveSmallInt) + `onboarding_completed_at` (DateTime) sur le modèle User, exposés en lecture seule via UserSerializer (donc présents dans la réponse de login).
- Endpoint `PATCH /users/me/onboarding/` self-scopé sur request.user (permission IsAuthenticated), validation linéaire du step (monotone, +1 max, borné 0–3), pose de completed_at au terminal.
- Data migration backfill : les utilisateurs existants au déploiement sont marqués onboardés (RG3305.05).

## Impacts
Back / API / DB (migration 0011, +2 colonnes sur `user`). Pas de Front. Endpoint nouveau, aucun existant modifié.

## Tests réalisés
Tests unitaires ajoutés (avance, complétion idempotente, self-scoping, anti-décrément, linéarité, hors-borne, auth requise, routing). Validés en local par `manage.py check` + compilation ; la suite Django nécessite Postgres (absent en local) et tournera en CI.

## Risques
Migration backfill sur la table `user` (update ciblé, exclut les soft-deleted). Aucun changement de comportement sur les endpoints users existants.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added onboarding progress tracking to user profiles, including current step and completion timestamp.
  * Introduced a profile endpoint to update onboarding progress step-by-step.

* **Bug Fixes**
  * Existing users are now automatically marked as onboarded when appropriate.
  * Final onboarding completion is recorded once and won’t be overwritten on later updates.

* **Tests**
  * Added coverage for onboarding progress rules, access control, and profile serialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->