### PR TITLE
feat: assurer la continuité des requêtes CCAM après segmentation (3371)

### DIFF
--- a/cohort/scripts/patch_requests_v163.py
+++ b/cohort/scripts/patch_requests_v163.py
@@ -3,9 +3,8 @@ from cohort.scripts.query_request_updater import MATCH_ALL_VALUES, QueryRequestU
 
 NEW_VERSION = "v1.6.3"
 
-# "000001 - ARBORESCENCE CCAM" était la racine commune à tout le référentiel CCAM. Le noeud a été supprimé du
-# référentiel ; une requête qui le portait doit désormais couvrir l'ensemble des codes CCAM, soit un match-all
-# sur le champ code (*). Les codes feuilles cassés par la segmentation sont traités à l'exécution, pas ici.
+# "000001 - ARBORESCENCE CCAM" était la racine du référentiel, désormais supprimée : une requête qui la portait
+# doit couvrir tout le CCAM. Les codes feuilles segmentés sont traités à l'exécution, pas ici.
 CCAM_ROOT_CODE = "000001"
 
 

--- a/cohort/scripts/patch_requests_v163.py
+++ b/cohort/scripts/patch_requests_v163.py
@@ -1,0 +1,39 @@
+from cohort.scripts.patch_requests_v162 import NEW_VERSION as PREV_VERSION
+from cohort.scripts.query_request_updater import MATCH_ALL_VALUES, QueryRequestUpdater
+
+NEW_VERSION = "v1.6.3"
+
+# "000001 - ARBORESCENCE CCAM" était la racine commune à tout le référentiel CCAM. Le noeud a été supprimé du
+# référentiel ; une requête qui le portait doit désormais couvrir l'ensemble des codes CCAM, soit un match-all
+# sur le champ code (*). Les codes feuilles cassés par la segmentation sont traités à l'exécution, pas ici.
+CCAM_ROOT_CODE = "000001"
+
+
+def code_part(token: str) -> str:
+    return token.split("|", 1)[1] if "|" in token else token
+
+
+def replace_ccam_root_with_match_all(codes: str) -> str:
+    return ",".join("*" if code_part(token.strip()) == CCAM_ROOT_CODE else token for token in codes.split(","))
+
+
+FILTER_MAPPING = {}
+
+FILTER_NAME_TO_SKIP = {}
+
+FILTER_VALUE_MAPPING = {"Procedure": {"code": {MATCH_ALL_VALUES: replace_ccam_root_with_match_all}}}
+
+STATIC_REQUIRED_FILTERS = {}
+
+RESOURCE_NAME_MAPPING = {}
+
+
+updater = QueryRequestUpdater(
+    version_name=NEW_VERSION,
+    previous_version_name=[PREV_VERSION],
+    filter_mapping=FILTER_MAPPING,
+    filter_names_to_skip=FILTER_NAME_TO_SKIP,
+    filter_values_mapping=FILTER_VALUE_MAPPING,
+    static_required_filters=STATIC_REQUIRED_FILTERS,
+    resource_name_mapping=RESOURCE_NAME_MAPPING,
+)

--- a/cohort/tests/test_query_request_updater.py
+++ b/cohort/tests/test_query_request_updater.py
@@ -3,7 +3,10 @@ import json
 
 from admin_cohort.tests.tests_tools import BaseTests
 from cohort.scripts.patch_requests_v145 import return_filter_if_not_exist
+from cohort.scripts.patch_requests_v163 import replace_ccam_root_with_match_all, updater
 from cohort.scripts.query_request_updater import QueryRequestUpdater
+
+CCAM = "https://aphp.fr/ig/fhir/core/CodeSystem/CCAMDescriptiveVerAPHP"
 
 
 class TestQueryRequestUpdater(BaseTests):
@@ -94,3 +97,34 @@ class TestQueryRequestUpdater(BaseTests):
 @dataclasses.dataclass
 class Request:
     serialized_query: str
+
+
+class TestPatchRequestsV163(BaseTests):
+    def test_bare_root_becomes_match_all(self):
+        self.assertEqual("*", replace_ccam_root_with_match_all("000001"))
+
+    def test_root_with_system_becomes_match_all(self):
+        self.assertEqual("*", replace_ccam_root_with_match_all(f"{CCAM}|000001"))
+
+    def test_leaf_code_left_untouched(self):
+        self.assertEqual(f"{CCAM}|JQGA004", replace_ccam_root_with_match_all(f"{CCAM}|JQGA004"))
+
+    def test_numeric_branch_node_left_untouched(self):
+        self.assertEqual(f"{CCAM}|000124", replace_ccam_root_with_match_all(f"{CCAM}|000124"))
+
+    def test_only_root_token_replaced_in_list(self):
+        self.assertEqual(f"*,{CCAM}|JQGA004", replace_ccam_root_with_match_all(f"{CCAM}|000001,{CCAM}|JQGA004"))
+
+    def test_end_to_end_procedure_criteria(self):
+        query = {
+            "version": "v1.6.2",
+            "_type": "resource",
+            "resourceType": "Procedure",
+            "fhirFilter": f"code={CCAM}|000001",
+        }
+        saved = []
+        updater.do_update_old_query_snapshots([Request(json.dumps(query))], lambda r: saved.append(r.serialized_query), dry_run=False, debug=False)
+        self.assertEqual(1, len(saved))
+        result = json.loads(saved[0])
+        self.assertEqual("v1.6.3", result["version"])
+        self.assertEqual("code=*", result["fhirFilter"])

--- a/cohort_job_server/query_executor_api/query_formatter.py
+++ b/cohort_job_server/query_executor_api/query_formatter.py
@@ -51,10 +51,24 @@ def add_security_params_to_filter_fhir(sub_criteria: Criteria, source_population
     return f"{META_SECURITY_PSEUDED}&{filter_fhir_enriched}" if is_pseudo else filter_fhir_enriched
 
 
-# Code CCAM au noeud-feuille : 4 lettres + 3 chiffres (ex. JQGA004), pris comme token complet. La nomenclature
-# FHIR a segmenté ces codes par activité (JQGA004 -> JQGA004xx) : le code feuille seul ne matche plus, on le
-# cherche donc en préfixe. Le lookbehind/lookahead évite de toucher un code segmenté ou déjà suffixé de *.
-CCAM_LEAF_CODE_RE = re.compile(r"(?<![0-9A-Za-z])([A-Z]{4}[0-9]{3})(?![0-9A-Za-z*])")
+# Procedure ne porte que du CCAM (EDS), donc un token sans système est du CCAM legacy.
+CCAM_CODESYSTEMS = frozenset(
+    {
+        "https://www.atih.sante.fr/plateformes-de-transmission-et-logiciels/logiciels-espace-de-telechargement/id_lot/3550",
+        "https://terminology.eds.aphp.fr/aphp-orbis-ccam",
+        "https://aphp.fr/ig/fhir/core/CodeSystem/CCAMDescriptiveVerAPHP",
+    }
+)
+
+# Code CCAM au noeud-feuille (ex. JQGA004), segmenté par activité côté FHIR.
+CCAM_LEAF_CODE_RE = re.compile(r"[A-Z]{4}[0-9]{3}")
+
+
+def prefix_ccam_leaf_code(token: str) -> str:
+    system, sep, code = token.rpartition("|")
+    if sep and system not in CCAM_CODESYSTEMS:
+        return token
+    return f"{system}{sep}{code}*" if CCAM_LEAF_CODE_RE.fullmatch(code) else token
 
 
 def add_prefix_search_on_ccam_leaves(filter_fhir: str, resource_type: ResourceType) -> str:
@@ -64,7 +78,7 @@ def add_prefix_search_on_ccam_leaves(filter_fhir: str, resource_type: ResourceTy
     for param in filter_fhir.split("&"):
         key, sep, value = param.partition("=")
         if sep and key.split(":", 1)[0] == "code":
-            value = CCAM_LEAF_CODE_RE.sub(r"\1*", value)
+            value = ",".join(prefix_ccam_leaf_code(token) for token in value.split(","))
         params.append(f"{key}{sep}{value}")
     return "&".join(params)
 

--- a/cohort_job_server/query_executor_api/query_formatter.py
+++ b/cohort_job_server/query_executor_api/query_formatter.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import os
+import re
 import urllib.parse
 from typing import TYPE_CHECKING
 
@@ -50,6 +51,24 @@ def add_security_params_to_filter_fhir(sub_criteria: Criteria, source_population
     return f"{META_SECURITY_PSEUDED}&{filter_fhir_enriched}" if is_pseudo else filter_fhir_enriched
 
 
+# Code CCAM au noeud-feuille : 4 lettres + 3 chiffres (ex. JQGA004), pris comme token complet. La nomenclature
+# FHIR a segmenté ces codes par activité (JQGA004 -> JQGA004xx) : le code feuille seul ne matche plus, on le
+# cherche donc en préfixe. Le lookbehind/lookahead évite de toucher un code segmenté ou déjà suffixé de *.
+CCAM_LEAF_CODE_RE = re.compile(r"(?<![0-9A-Za-z])([A-Z]{4}[0-9]{3})(?![0-9A-Za-z*])")
+
+
+def add_prefix_search_on_ccam_leaves(filter_fhir: str, resource_type: ResourceType) -> str:
+    if not filter_fhir or resource_type != ResourceType.PROCEDURE:
+        return filter_fhir
+    params = []
+    for param in filter_fhir.split("&"):
+        key, sep, value = param.partition("=")
+        if sep and key.split(":", 1)[0] == "code":
+            value = CCAM_LEAF_CODE_RE.sub(r"\1*", value)
+        params.append(f"{key}{sep}{value}")
+    return "&".join(params)
+
+
 class QueryFormatter:
     IDENTIFIER_VALUE = "identifier.value"
 
@@ -63,6 +82,7 @@ class QueryFormatter:
                 return None
 
             if criteria.criteria_type == CriteriaType.BASIC_RESOURCE:
+                criteria.filter_fhir = add_prefix_search_on_ccam_leaves(criteria.filter_fhir, criteria.resource_type)
                 filter_fhir_enriched = add_security_params_to_filter_fhir(criteria, source_population, is_pseudo)
 
                 logger.info(f"filterFhirEnriched {filter_fhir_enriched}")

--- a/cohort_job_server/tests/test_query_executor_api.py
+++ b/cohort_job_server/tests/test_query_executor_api.py
@@ -14,6 +14,7 @@ from cohort_job_server.query_executor_api.query_formatter import add_prefix_sear
 from cohort_job_server.query_executor_api.schemas import FhirParameters, FhirParameter, CohortQuery
 
 CCAM = "https://aphp.fr/ig/fhir/core/CodeSystem/CCAMDescriptiveVerAPHP"
+ATIH = "https://www.atih.sante.fr/plateformes-de-transmission-et-logiciels/logiciels-espace-de-telechargement/id_lot/3550"
 
 
 class FhirResponseMapperTest(TestCase):
@@ -224,3 +225,9 @@ class TestCcamLeafStartsWith(TestCase):
 
     def test_other_code_prefixed_param_untouched(self):
         self.assertEqual("codeList=JQGA004", add_prefix_search_on_ccam_leaves("codeList=JQGA004", ResourceType.PROCEDURE))
+
+    def test_atih_codesystem_becomes_prefix(self):
+        self.assertEqual(f"code={ATIH}|JQGA004*", add_prefix_search_on_ccam_leaves(f"code={ATIH}|JQGA004", ResourceType.PROCEDURE))
+
+    def test_non_ccam_codesystem_untouched(self):
+        self.assertEqual("code=http://other|JQGA004", add_prefix_search_on_ccam_leaves("code=http://other|JQGA004", ResourceType.PROCEDURE))

--- a/cohort_job_server/tests/test_query_executor_api.py
+++ b/cohort_job_server/tests/test_query_executor_api.py
@@ -10,7 +10,10 @@ from cohort_job_server.apps import CohortJobServerConfig
 from cohort_job_server.query_executor_api import QueryFormatter, BaseCohortRequest
 from cohort_job_server.query_executor_api.enums import ResourceType
 from cohort_job_server.query_executor_api.exceptions import FhirException
+from cohort_job_server.query_executor_api.query_formatter import add_prefix_search_on_ccam_leaves
 from cohort_job_server.query_executor_api.schemas import FhirParameters, FhirParameter, CohortQuery
+
+CCAM = "https://aphp.fr/ig/fhir/core/CodeSystem/CCAMDescriptiveVerAPHP"
 
 
 class FhirResponseMapperTest(TestCase):
@@ -166,3 +169,58 @@ class TestQueryFormatter(TestCase):
         user1 = User.objects.create(firstname="Test", lastname="USER", email="test.user@aphp.fr", username="1111111")
         read_in_pseudo = BaseCohortRequest.is_cohort_request_pseudo_read(username=user1.username, source_population=[])
         self.assertTrue(read_in_pseudo)
+
+    @mock.patch("cohort_job_server.query_executor_api.query_formatter.query_fhir")
+    def test_format_to_fhir_adds_prefix_on_ccam_leaf(self, query_fhir):
+        query_fhir.return_value = self.mocked_query_fhir_result
+        query = CohortQuery(
+            **{
+                "_type": "request",
+                "sourcePopulation": {"caresiteCohortList": []},
+                "request": {
+                    "_type": "basicResource",
+                    "_id": 1,
+                    "isInclusive": True,
+                    "resourceType": "Procedure",
+                    "filterFhir": f"code={CCAM}|JQGA004",
+                },
+            }
+        )
+        res = self.query_formatter.format_to_fhir(query, False)
+        self.assertEqual(f"code={CCAM}|JQGA004*", res.filter_fhir)
+
+
+class TestCcamLeafStartsWith(TestCase):
+    def test_leaf_code_with_system_becomes_prefix(self):
+        self.assertEqual(f"code={CCAM}|JQGA004*", add_prefix_search_on_ccam_leaves(f"code={CCAM}|JQGA004", ResourceType.PROCEDURE))
+
+    def test_bare_leaf_code_becomes_prefix(self):
+        self.assertEqual("code=JQGA004*", add_prefix_search_on_ccam_leaves("code=JQGA004", ResourceType.PROCEDURE))
+
+    def test_comma_separated_leaves(self):
+        self.assertEqual("code=JQGA004*,HGEA002*", add_prefix_search_on_ccam_leaves("code=JQGA004,HGEA002", ResourceType.PROCEDURE))
+
+    def test_numeric_branch_node_untouched(self):
+        self.assertEqual("code=000124", add_prefix_search_on_ccam_leaves("code=000124", ResourceType.PROCEDURE))
+
+    def test_already_wildcarded_is_idempotent(self):
+        self.assertEqual("code=JQGA004*", add_prefix_search_on_ccam_leaves("code=JQGA004*", ResourceType.PROCEDURE))
+
+    def test_segmented_activity_code_untouched(self):
+        self.assertEqual("code=JQGA0041201", add_prefix_search_on_ccam_leaves("code=JQGA0041201", ResourceType.PROCEDURE))
+
+    def test_other_params_untouched(self):
+        filter_fhir = f"patient-active=true&code={CCAM}|JQGA004"
+        self.assertEqual(f"patient-active=true&code={CCAM}|JQGA004*", add_prefix_search_on_ccam_leaves(filter_fhir, ResourceType.PROCEDURE))
+
+    def test_non_procedure_resource_untouched(self):
+        self.assertEqual("code=JQGA004", add_prefix_search_on_ccam_leaves("code=JQGA004", ResourceType.CONDITION))
+
+    def test_empty_filter_untouched(self):
+        self.assertEqual("", add_prefix_search_on_ccam_leaves("", ResourceType.PROCEDURE))
+
+    def test_code_modifier_is_expanded(self):
+        self.assertEqual("code:not=JQGA004*", add_prefix_search_on_ccam_leaves("code:not=JQGA004", ResourceType.PROCEDURE))
+
+    def test_other_code_prefixed_param_untouched(self):
+        self.assertEqual("codeList=JQGA004", add_prefix_search_on_ccam_leaves("codeList=JQGA004", ResourceType.PROCEDURE))


### PR DESCRIPTION
## Objectif
Fixes https://gitlab.data.aphp.fr/ID/design-et-produit/ipa/cohort360/gestion-de-projet/-/issues/3371

La segmentation des codes CCAM par activité (JQGA004 → JQGA004xx) casse les requêtes existantes : les anciens codes feuilles ne renvoient plus de résultats. Le noeud racine « 000001 - ARBORESCENCE CCAM » a par ailleurs été supprimé du référentiel.

## Changements réalisés
- À l'exécution, les codes CCAM feuilles d'un critère `Procedure` sont cherchés en préfixe (`JQGA004` → `JQGA004*`), sans réécrire les requêtes enregistrées. Le `*` est passé tel quel à Solr par FhirApi.
- Patch de migration v1.6.3 : dans les requêtes stockées, le code racine `000001` (Procedure) est remplacé par un match-all `*` (couvre tout le CCAM).

## Impacts
Back uniquement. Le bump `REQUETEUR_VERSION` v1.6.2 → v1.6.3 côté front fera l'objet d'une PR séparée (requis pour que la migration ne cible que les anciennes requêtes). Le patch v1.6.3 se lance manuellement au MEP (dry-run d'abord).

## Tests réalisés
Unitaires : helper préfixe (feuilles, noeuds de branche numériques, modificateurs, idempotence, codes segmentés) et patch 000001 (brut / systémé, listes, bout-en-bout via l'updater). 27 tests verts.

## Risques
Le préfixe repose sur le passage du `*` non-échappé par FhirApi (vérifié dans `TokenParams`). RG3371.02 (ne plus afficher 000001) est déjà réglé par l'upgrade FhirApi en preprod, hors périmètre back.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Procedure searches now support broader CCAM matching by expanding CCAM leaf codes to wildcard (prefix) form.
  * Legacy saved queries are updated to replace CCAM “root” codes within code lists so they can match all CCAM codes.

* **Bug Fixes**
  * Improved handling of comma-separated CCAM code lists, including proper treatment of negated code filters.
  * Ensures only the targeted Procedure CCAM `code` filter segments are rewritten, leaving other parameters and already-wildcarded values unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->