### PR TITLE
fix(query): prefix-search all CCAM codes, not only alpha leaves (3371)

### DIFF
--- a/cohort_job_server/query_executor_api/query_formatter.py
+++ b/cohort_job_server/query_executor_api/query_formatter.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import logging
 import os
-import re
 import urllib.parse
 from typing import TYPE_CHECKING
 
@@ -60,15 +59,17 @@ CCAM_CODESYSTEMS = frozenset(
     }
 )
 
-# Code CCAM au noeud-feuille (ex. JQGA004), segmenté par activité côté FHIR.
-CCAM_LEAF_CODE_RE = re.compile(r"[A-Z]{4}[0-9]{3}")
-
 
 def prefix_ccam_leaf_code(token: str) -> str:
+    # Le référentiel CCAM a été ré-encodé (segmentation des actes, suffixe de niveau sur les
+    # noeuds) : un code stocké ne matche plus à l'identique, quel que soit son format. On le
+    # cherche donc en préfixe, sauf s'il porte déjà un `*` ou un système non-CCAM.
     system, sep, code = token.rpartition("|")
     if sep and system not in CCAM_CODESYSTEMS:
         return token
-    return f"{system}{sep}{code}*" if CCAM_LEAF_CODE_RE.fullmatch(code) else token
+    if not code or code.endswith("*"):
+        return token
+    return f"{system}{sep}{code}*"
 
 
 def add_prefix_search_on_ccam_leaves(filter_fhir: str, resource_type: ResourceType) -> str:

--- a/cohort_job_server/query_executor_api/query_formatter.py
+++ b/cohort_job_server/query_executor_api/query_formatter.py
@@ -78,7 +78,9 @@ def add_prefix_search_on_ccam_leaves(filter_fhir: str, resource_type: ResourceTy
     params = []
     for param in filter_fhir.split("&"):
         key, sep, value = param.partition("=")
-        if sep and key.split(":", 1)[0] == "code":
+        base, _, modifier = key.partition(":")
+        # `code:in` / `code:not-in` portent une URI de ValueSet, pas des codes : on ne les touche pas.
+        if sep and base == "code" and modifier in ("", "not"):
             value = ",".join(prefix_ccam_leaf_code(token) for token in value.split(","))
         params.append(f"{key}{sep}{value}")
     return "&".join(params)

--- a/cohort_job_server/tests/test_query_executor_api.py
+++ b/cohort_job_server/tests/test_query_executor_api.py
@@ -201,14 +201,15 @@ class TestCcamLeafStartsWith(TestCase):
     def test_comma_separated_leaves(self):
         self.assertEqual("code=JQGA004*,HGEA002*", add_prefix_search_on_ccam_leaves("code=JQGA004,HGEA002", ResourceType.PROCEDURE))
 
-    def test_numeric_branch_node_untouched(self):
-        self.assertEqual("code=000124", add_prefix_search_on_ccam_leaves("code=000124", ResourceType.PROCEDURE))
+    def test_numeric_node_becomes_prefix(self):
+        # Les noeuds numériques (chapitres/branches) ont aussi été ré-encodés : cherchés en préfixe.
+        self.assertEqual("code=000124*", add_prefix_search_on_ccam_leaves("code=000124", ResourceType.PROCEDURE))
 
     def test_already_wildcarded_is_idempotent(self):
         self.assertEqual("code=JQGA004*", add_prefix_search_on_ccam_leaves("code=JQGA004*", ResourceType.PROCEDURE))
 
-    def test_segmented_activity_code_untouched(self):
-        self.assertEqual("code=JQGA0041201", add_prefix_search_on_ccam_leaves("code=JQGA0041201", ResourceType.PROCEDURE))
+    def test_segmented_activity_code_becomes_prefix(self):
+        self.assertEqual("code=JQGA0041201*", add_prefix_search_on_ccam_leaves("code=JQGA0041201", ResourceType.PROCEDURE))
 
     def test_other_params_untouched(self):
         filter_fhir = f"patient-active=true&code={CCAM}|JQGA004"

--- a/cohort_job_server/tests/test_query_executor_api.py
+++ b/cohort_job_server/tests/test_query_executor_api.py
@@ -224,6 +224,12 @@ class TestCcamLeafStartsWith(TestCase):
     def test_code_modifier_is_expanded(self):
         self.assertEqual("code:not=JQGA004*", add_prefix_search_on_ccam_leaves("code:not=JQGA004", ResourceType.PROCEDURE))
 
+    def test_valueset_modifiers_untouched(self):
+        # `code:in` / `code:not-in` portent une URI de ValueSet, jamais wildcardée.
+        vs = "https://smt.esante.gouv.fr/terminologie-ccam"
+        self.assertEqual(f"code:in={vs}", add_prefix_search_on_ccam_leaves(f"code:in={vs}", ResourceType.PROCEDURE))
+        self.assertEqual(f"code:not-in={vs}", add_prefix_search_on_ccam_leaves(f"code:not-in={vs}", ResourceType.PROCEDURE))
+
     def test_other_code_prefixed_param_untouched(self):
         self.assertEqual("codeList=JQGA004", add_prefix_search_on_ccam_leaves("codeList=JQGA004", ResourceType.PROCEDURE))
 


### PR DESCRIPTION
## Objectif
Fixes https://gitlab.data.aphp.fr/ID/design-et-produit/ipa/cohort360/gestion-de-projet/-/work_items/3371

Complément de #552. La règle de préfixe CCAM ne couvrait que les feuilles alphanumériques (regex `[A-Z]{4}[0-9]{3}`) et ratait les chapitres/sous-chapitres numériques ré-encodés (ex. `001472`).

## Changements réalisés
Le préfixe `*` est désormais appliqué par défaut à **tout** code CCAM stocké (chapitres, sous-chapitres, feuilles), plus seulement aux feuilles `:alpha:{4}\d+`. Idempotent sur les codes déjà en `*`, systèmes non-CCAM et autres ressources intacts. Suppression du regex feuille.

## Impacts
Back uniquement (requêteur / count). Comportement iso pour les requêtes sans code CCAM.

## Tests réalisés
TU updated

## Risques
Pas de collision entre codes : chapitres (6 chiffres zero-paddés) et feuilles (4 lettres + 3 chiffres) s'incrémentent par unité, un préfixe ne déborde pas sur le code voisin (confirmé côté référentiel). L'affichage des codes dans le requêteur est hors périmètre (PR front séparée).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * CCAM procedure searches now more consistently use prefix matching for eligible codes, improving search results for leaf-level procedure codes.
  * Codes that are already wildcarded remain unchanged, while non-CCAM entries are left as-is.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->