### PR TITLE
feat(users): record charter signature date on user (3309)

### DIFF
--- a/admin_cohort/migrations/0012_user_charter_signed_at.py
+++ b/admin_cohort/migrations/0012_user_charter_signed_at.py
@@ -1,0 +1,17 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("admin_cohort", "0011_user_onboarding"),
+    ]
+
+    operations = [
+        # Users onboarded before this migration never signed the charter: leave them null
+        # rather than backfilling a signature date they did not consent to.
+        migrations.AddField(
+            model_name="user",
+            name="charter_signed_at",
+            field=models.DateTimeField(blank=True, null=True),
+        ),
+    ]

--- a/admin_cohort/models/user.py
+++ b/admin_cohort/models/user.py
@@ -17,6 +17,7 @@ class User(AbstractBaseUser, BaseModel):
     updated_by = models.ForeignKey("self", on_delete=models.SET_NULL, related_name="updated_users", null=True, blank=True, db_column="updated_by")
     onboarding_step = models.PositiveSmallIntegerField(default=0)
     onboarding_completed_at = models.DateTimeField(blank=True, null=True)
+    charter_signed_at = models.DateTimeField(blank=True, null=True)
 
     def __str__(self):
         return f"{self.firstname} {self.lastname} ({self.username})"

--- a/admin_cohort/serializers.py
+++ b/admin_cohort/serializers.py
@@ -55,6 +55,7 @@ class UserSerializer(serializers.ModelSerializer):
     updated_by: serializers.SlugRelatedField = serializers.SlugRelatedField(read_only=True, slug_field="display_name")
     onboarding_step = serializers.IntegerField(read_only=True)
     onboarding_completed_at = serializers.DateTimeField(read_only=True)
+    charter_signed_at = serializers.DateTimeField(read_only=True)
 
     class Meta:
         model = User
@@ -69,6 +70,7 @@ class UserSerializer(serializers.ModelSerializer):
             "updated_by",
             "onboarding_step",
             "onboarding_completed_at",
+            "charter_signed_at",
         ]
 
 
@@ -97,6 +99,22 @@ class OnboardingSerializer(serializers.ModelSerializer):
             instance.updated_by = validated_data["updated_by"]
             update_fields.append("updated_by")
         instance.save(update_fields=update_fields)
+        return instance
+
+
+class CharterSignatureSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = User
+        fields = ["charter_signed_at"]
+        read_only_fields = ["charter_signed_at"]
+
+    def sign(self, signed_by):
+        # Signing is idempotent: only the first signature date has legal value.
+        instance = self.instance
+        if instance.charter_signed_at is None:
+            instance.charter_signed_at = timezone.now()
+            instance.updated_by = signed_by
+            instance.save(update_fields=["charter_signed_at", "updated_by", "update_datetime"])
         return instance
 
 

--- a/admin_cohort/tests/tests_view_user.py
+++ b/admin_cohort/tests/tests_view_user.py
@@ -236,6 +236,7 @@ class UserTestsAsAdmin(UserTests):
         payload = self.get_response_payload(response)
         self.assertIn("onboarding_step", payload)
         self.assertIn("onboarding_completed_at", payload)
+        self.assertIn("charter_signed_at", payload)
 
 
 ONBOARDING_URL = "/users/me/onboarding/"
@@ -310,4 +311,47 @@ class UserOnboardingTests(UserTests):
     def test_requires_authentication(self):
         client = APIClient()
         response = client.patch(ONBOARDING_URL, dict(onboarding_step=1), format="json")
+        self.assertIn(response.status_code, (status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN))
+
+
+CHARTER_URL = "/users/me/onboarding/charter/"
+
+
+class CharterSignatureTests(UserTests):
+    def _sign_charter(self, user):
+        # go through the router so the action's permission_classes (IsAuthenticated) apply
+        client = APIClient()
+        client.force_authenticate(user)
+        return client.post(CHARTER_URL, format="json")
+
+    def test_signing_records_the_timestamp(self):
+        # user3 has no admin rights: this proves the endpoint is self-scoped, not gated by UsersPermission
+        response = self._sign_charter(self.user3)
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
+        self.user3.refresh_from_db()
+        self.assertIsNotNone(self.user3.charter_signed_at)
+        self.assertEqual(self.user3.updated_by_id, self.user3.username)
+        self.assertIsNotNone(response.json()["charter_signed_at"])
+
+    def test_signing_twice_keeps_the_first_date(self):
+        self._sign_charter(self.user1)
+        self.user1.refresh_from_db()
+        first_signature = self.user1.charter_signed_at
+
+        response = self._sign_charter(self.user1)
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
+        self.user1.refresh_from_db()
+        self.assertEqual(self.user1.charter_signed_at, first_signature)
+
+    def test_signature_is_self_scoped(self):
+        self._sign_charter(self.user1)
+        self.user2.refresh_from_db()
+        self.assertIsNone(self.user2.charter_signed_at)
+
+    def test_charter_is_unsigned_by_default(self):
+        self.assertIsNone(self.user1.charter_signed_at)
+
+    def test_requires_authentication(self):
+        client = APIClient()
+        response = client.post(CHARTER_URL, format="json")
         self.assertIn(response.status_code, (status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN))

--- a/admin_cohort/views/users.py
+++ b/admin_cohort/views/users.py
@@ -14,7 +14,7 @@ from rest_framework.response import Response
 
 from admin_cohort.models import User
 from admin_cohort.permissions import UsersPermission
-from admin_cohort.serializers import UserSerializer, UserCheckSerializer, OnboardingSerializer
+from admin_cohort.serializers import UserSerializer, UserCheckSerializer, OnboardingSerializer, CharterSignatureSerializer
 from admin_cohort.services.users import users_service
 from admin_cohort.tools.cache import cache_response
 from admin_cohort.exceptions import ServerError
@@ -130,4 +130,11 @@ class UserViewSet(RequestLogMixin, viewsets.ModelViewSet):
         serializer = OnboardingSerializer(instance=request.user, data=request.data)
         serializer.is_valid(raise_exception=True)
         serializer.save(updated_by=request.user)
+        return Response(data=serializer.data, status=status.HTTP_200_OK)
+
+    @extend_schema(tags=["Users"], request=None, responses={status.HTTP_200_OK: CharterSignatureSerializer})
+    @action(detail=False, methods=["post"], url_path="me/onboarding/charter", permission_classes=[IsAuthenticated])
+    def sign_charter(self, request, *args, **kwargs):
+        serializer = CharterSignatureSerializer(instance=request.user)
+        serializer.sign(signed_by=request.user)
         return Response(data=serializer.data, status=status.HTTP_200_OK)


### PR DESCRIPTION
## Objectif

RG3309.02 impose de tracer en base la signature de la charte d'engagement. Aujourd'hui `onboarding_step` prouve seulement que l'utilisateur a franchi l'étape 2, sans dire qu'il a signé ni quand.

Fixes [gestion-de-projet#3309](https://gitlab.data.aphp.fr/ID/design-et-produit/ipa/cohort360/gestion-de-projet/-/work_items/3309)

⚠️ Un migration sera a apply

## Changements réalisés

- Champ `User.charter_signed_at` (nullable) et migration `0012`.
- `POST /users/me/onboarding/charter/` : horodate la signature de l'utilisateur connecté et renvoie la date.
- `charter_signed_at` exposé en lecture seule par `UserSerializer`, pour que le front hydrate son état à la connexion.

La signature est idempotente : un second appel renvoie la première date sans l'écraser.

## Impacts

- **DB** : une colonne nullable ajoutée. Les utilisateurs marqués comme onboardés par la migration `0011` ne sont **pas** backfillés : ils n'ont jamais signé, la colonne reste `NULL` plutôt que d'inventer un consentement.
- **API** : un endpoint ajouté, self-scoped (`IsAuthenticated`, agit sur `request.user`). `UserSerializer` gagne un champ en lecture seule.
- **Droits** : aucun changement.

## Tests réalisés

Unitaires (`admin_cohort/tests/tests_view_user.py`) : enregistrement de l'horodatage, idempotence, isolation entre utilisateurs, non-signé par défaut, authentification requise, exposition du champ par le serializer.

Non exécutés localement (environnement Django absent de ma machine) : la CI les passe.

## Risques

Base de la PR : `feat/3305-onboarding-shell`, où vit l'onboarding back depuis le revert de #550. À intégrer avec elle, pas isolément.
