### PR TITLE
ci: allow backend frigo Docker publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,6 +11,7 @@ on:
     branches:
       - main
       - develop
+      - backend-frigo
       - 'release/**'
 
 jobs:
@@ -49,6 +50,9 @@ jobs:
               ;;
             develop)
               echo "IMAGE_TAGS=aphpid/cohort360-backend:develop" >> "$GITHUB_ENV"
+              ;;
+            backend-frigo)
+              echo "IMAGE_TAGS=aphpid/cohort360-backend:backend-frigo" >> "$GITHUB_ENV"
               ;;
             release/*)
               echo "IMAGE_TAGS=aphpid/cohort360-backend:${VERSION}-rc,aphpid/cohort360-backend:${VERSION}-rc.${SHORT_SHA}" >> "$GITHUB_ENV"


### PR DESCRIPTION
﻿## Objet

Autoriser la publication Docker depuis la branche `backend-frigo`.

## Changements

- Ajoute `backend-frigo` au filtre `workflow_run.branches` du workflow `publish.yml`.
- Ajoute le tag Docker `aphpid/cohort360-backend:backend-frigo` pour cette branche.

## Contexte

Le workflow `workflow_run` doit être présent sur la branche par défaut pour se déclencher. Cette PR porte donc la règle sur `develop` afin que les runs de test `backend-frigo` puissent déclencher le publish.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added support for publishing Docker images from the `backend-frigo` branch.
  * Images built from this branch are now tagged separately for deployment and release workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->