### PR TITLE
feat(users): statut d'onboarding via GET me/onboarding

### DIFF
--- a/admin_cohort/serializers.py
+++ b/admin_cohort/serializers.py
@@ -118,6 +118,13 @@ class CharterSignatureSerializer(serializers.ModelSerializer):
         return instance
 
 
+class OnboardingStatusSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = User
+        fields = ["onboarding_step", "onboarding_completed_at", "charter_signed_at"]
+        read_only_fields = fields
+
+
 class UserCreateSerializer(serializers.ModelSerializer):
     username = serializers.CharField(required=True)
     firstname = serializers.CharField(required=True)

--- a/admin_cohort/tests/tests_view_user.py
+++ b/admin_cohort/tests/tests_view_user.py
@@ -355,3 +355,39 @@ class CharterSignatureTests(UserTests):
         client = APIClient()
         response = client.post(CHARTER_URL, format="json")
         self.assertIn(response.status_code, (status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN))
+
+
+class OnboardingStatusTests(UserTests):
+    def _get_onboarding(self, user):
+        client = APIClient()
+        client.force_authenticate(user)
+        return client.get(ONBOARDING_URL)
+
+    def test_returns_the_current_progress(self):
+        self.user1.onboarding_step = User.ONBOARDING_TOTAL_STEPS
+        self.user1.onboarding_completed_at = timezone.now()
+        self.user1.save()
+        response = self._get_onboarding(self.user1)
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
+        payload = response.json()
+        self.assertEqual(payload["onboarding_step"], User.ONBOARDING_TOTAL_STEPS)
+        self.assertIsNotNone(payload["onboarding_completed_at"])
+        self.assertIn("charter_signed_at", payload)
+
+    def test_reflects_a_fresh_user(self):
+        response = self._get_onboarding(self.user3)
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
+        payload = response.json()
+        self.assertEqual(payload["onboarding_step"], 0)
+        self.assertIsNone(payload["onboarding_completed_at"])
+        self.assertIsNone(payload["charter_signed_at"])
+
+    def test_is_self_scoped(self):
+        User.objects.filter(pk=self.user2.pk).update(onboarding_step=2)
+        payload = self._get_onboarding(self.user1).json()
+        self.assertEqual(payload["onboarding_step"], 0)
+
+    def test_requires_authentication(self):
+        client = APIClient()
+        response = client.get(ONBOARDING_URL)
+        self.assertIn(response.status_code, (status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN))

--- a/admin_cohort/views/users.py
+++ b/admin_cohort/views/users.py
@@ -14,7 +14,7 @@ from rest_framework.response import Response
 
 from admin_cohort.models import User
 from admin_cohort.permissions import UsersPermission
-from admin_cohort.serializers import UserSerializer, UserCheckSerializer, OnboardingSerializer, CharterSignatureSerializer
+from admin_cohort.serializers import UserSerializer, UserCheckSerializer, OnboardingSerializer, OnboardingStatusSerializer, CharterSignatureSerializer
 from admin_cohort.services.users import users_service
 from admin_cohort.tools.cache import cache_response
 from admin_cohort.exceptions import ServerError
@@ -125,8 +125,10 @@ class UserViewSet(RequestLogMixin, viewsets.ModelViewSet):
         return Response(data={"message": "User not found"}, status=status.HTTP_404_NOT_FOUND)
 
     @extend_schema(tags=["Users"], request=OnboardingSerializer, responses={status.HTTP_200_OK: OnboardingSerializer})
-    @action(detail=False, methods=["patch"], url_path="me/onboarding", permission_classes=[IsAuthenticated])
-    def update_onboarding(self, request, *args, **kwargs):
+    @action(detail=False, methods=["get", "patch"], url_path="me/onboarding", permission_classes=[IsAuthenticated])
+    def me_onboarding(self, request, *args, **kwargs):
+        if request.method == "GET":
+            return Response(data=OnboardingStatusSerializer(request.user).data, status=status.HTTP_200_OK)
         serializer = OnboardingSerializer(instance=request.user, data=request.data)
         serializer.is_valid(raise_exception=True)
         serializer.save(updated_by=request.user)


### PR DESCRIPTION
## Objectif
Permettre au front de resynchroniser le statut d'onboarding d'une session depuis le serveur.

Fixes [gestion-de-projet#3382](https://gitlab.data.aphp.fr/ID/design-et-produit/ipa/cohort360/gestion-de-projet/-/work_items/3382)

## Changements réalisés
Ajout d'un `GET /users/me/onboarding/` renvoyant `onboarding_step`, `onboarding_completed_at` et `charter_signed_at` de l'utilisateur courant. L'action existante `me/onboarding` accepte désormais GET en plus de PATCH.

## Impacts
Back, API : nouvel endpoint en lecture seule, self-scoped, `IsAuthenticated`. Pas de changement de schéma. Consommé par https://github.com/aphp/Cohort360-FrontEnd/pull/1286.

## Tests réalisés
Unitaires

## Risques
None