### PR TITLE
fix(scripts): remove obsolete OMOP dependency from v162

### DIFF
--- a/cohort/scripts/patch_requests_v162.py
+++ b/cohort/scripts/patch_requests_v162.py
@@ -1,14 +1,5 @@
-import logging
-import sys
-
-from django.db import connections
-
 from cohort.scripts.patch_requests_v161 import NEW_VERSION as PREV_VERSION
-from cohort.scripts.query_request_updater import RESOURCE_DEFAULT, MATCH_ALL_VALUES, QueryRequestUpdater, find_mapped_code
-
-LOGGER = logging.getLogger(__name__)
-stream_handler = logging.StreamHandler(stream=sys.stdout)
-LOGGER.addHandler(stream_handler)
+from cohort.scripts.query_request_updater import RESOURCE_DEFAULT, MATCH_ALL_VALUES, QueryRequestUpdater
 
 NEW_VERSION = "v1.6.2"
 
@@ -18,8 +9,6 @@ FILTER_NAME_TO_SKIP = {}
 
 CCAM_OLD_CODESYSTEM = "https://www.atih.sante.fr/plateformes-de-transmission-et-logiciels/logiciels-espace-de-telechargement/id_lot/3550"
 CCAM_NEW_CODESYSTEM = "https://aphp.fr/ig/fhir/core/CodeSystem/CCAMDescriptiveVerAPHP"
-
-code_mapping_cache = {}
 
 
 def map_ccam_code_token(code_token: str) -> str:
@@ -36,18 +25,10 @@ def map_ccam_code_token(code_token: str) -> str:
     else:
         code = token
 
-    return find_mapped_code(
-        code,
-        CCAM_OLD_CODESYSTEM,
-        CCAM_NEW_CODESYSTEM,
-        lambda c: f"{CCAM_NEW_CODESYSTEM}|{c}",
-        connections["omop"],
-        code_mapping_cache,
-    )
+    return f"{CCAM_NEW_CODESYSTEM}|{code}"
 
 
 def map_ccam_codes(codes: str) -> str:
-    LOGGER.info(f"Translating CCAM codes {codes}")
     return ",".join([map_ccam_code_token(code_token) for code_token in codes.split(",")])
 
 

--- a/cohort/tests/test_query_request_updater.py
+++ b/cohort/tests/test_query_request_updater.py
@@ -3,6 +3,7 @@ import json
 
 from admin_cohort.tests.tests_tools import BaseTests
 from cohort.scripts.patch_requests_v145 import return_filter_if_not_exist
+from cohort.scripts.patch_requests_v162 import CCAM_OLD_CODESYSTEM, map_ccam_code_token, map_ccam_codes, updater_v162
 from cohort.scripts.patch_requests_v163 import replace_ccam_root_with_match_all, updater
 from cohort.scripts.query_request_updater import QueryRequestUpdater
 
@@ -97,6 +98,43 @@ class TestQueryRequestUpdater(BaseTests):
 @dataclasses.dataclass
 class Request:
     serialized_query: str
+
+
+class TestPatchRequestsV162(BaseTests):
+    def test_old_code_system_is_replaced_without_changing_code(self):
+        self.assertEqual(f"{CCAM}|JQGA004", map_ccam_code_token(f"{CCAM_OLD_CODESYSTEM}|JQGA004"))
+
+    def test_bare_code_gets_new_code_system(self):
+        self.assertEqual(f"{CCAM}|JQGA004", map_ccam_code_token("JQGA004"))
+
+    def test_new_code_system_is_left_untouched(self):
+        self.assertEqual(f"{CCAM}|JQGA004", map_ccam_code_token(f"{CCAM}|JQGA004"))
+
+    def test_other_code_system_is_left_untouched(self):
+        other_code = "https://example.org/CodeSystem/other|JQGA004"
+        self.assertEqual(other_code, map_ccam_code_token(other_code))
+
+    def test_multiple_codes_are_converted_independently(self):
+        other_code = "https://example.org/CodeSystem/other|OTHER"
+        codes = f"{CCAM_OLD_CODESYSTEM}|JQGA004,JQGA005,{CCAM}|JQGA006,{other_code}"
+        expected = f"{CCAM}|JQGA004,{CCAM}|JQGA005,{CCAM}|JQGA006,{other_code}"
+        self.assertEqual(expected, map_ccam_codes(codes))
+
+    def test_end_to_end_procedure_criteria(self):
+        query = {
+            "version": "v1.6.1",
+            "_type": "resource",
+            "resourceType": "Procedure",
+            "fhirFilter": f"code={CCAM_OLD_CODESYSTEM}|JQGA004",
+        }
+        saved = []
+        updater_v162.do_update_old_query_snapshots(
+            [Request(json.dumps(query))], lambda r: saved.append(r.serialized_query), dry_run=False, debug=False
+        )
+        self.assertEqual(1, len(saved))
+        result = json.loads(saved[0])
+        self.assertEqual("v1.6.2", result["version"])
+        self.assertEqual(f"code={CCAM}|JQGA004", result["fhirFilter"])
 
 
 class TestPatchRequestsV163(BaseTests):


### PR DESCRIPTION
## Contexte

Le patch `patch_requests_v162.py` migre les filtres `Procedure.code` de l'ancien CodeSystem CCAM ATIH vers le CodeSystem CCAM AP-HP.

Le code actuel dépend de `connections[omop]` et de `omop.concept_relationship`. Or le runtime Kubernetes expose la base référentielle sous l'alias `accesses_perimeters`, et la relation `omop.concept_relationship` est absente en qualification, préproduction et production. Le patch échoue donc avant d'atteindre son fallback.

## Cause racine

La recherche historique de correspondance CCAM repose sur un modèle OMOP qui n'est plus disponible. Aucun mapping vers le nouveau CodeSystem n'a été trouvé dans les référentiels actuels. Le fallback existant conservait déjà la valeur du code et remplaçait uniquement le CodeSystem.

## Modifications

- suppression de la dépendance à la connexion OMOP dans v162 ;
- suppression de l'appel à `find_mapped_code()` et du cache associé ;
- conservation de la valeur du code CCAM ;
- remplacement direct de l'ancien CodeSystem par le nouveau ;
- maintien inchangé des codes déjà au nouveau format et des autres CodeSystems ;
- suppression du logging des valeurs de codes ;
- ajout de tests unitaires et d'un test de migration v1.6.1 vers v1.6.2.

## Impact

Le patch v162 devient indépendant du schéma OMOP et peut appliquer la transformation déjà prévue par son fallback :

```text
ancienne-url-ccam|CODE -> nouvelle-url-ccam|CODE
```

La règle selon laquelle la valeur du code reste identique doit être confirmée par un développeur ou un référent CCAM avant l'application en production.

## Validation

- formatage Ruff appliqué aux deux fichiers modifiés ;
- tests Django locaux non exécutés : la construction de la dépendance `krb5` nécessite `krb5-config`, indisponible dans l'environnement Windows local ;
- validation attendue par la CI GitHub sous Linux.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated CCAM code handling to consistently use the new code system.
  * Preserved codes that already use the new system or belong to other systems.
  * Updated affected procedure criteria and version information during migration.

* **Tests**
  * Added coverage for individual, bare, existing, unrelated, and comma-separated codes.
  * Added end-to-end validation of procedure criteria updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->