### PR TITLE
fix: make request filter updates compatible with current models

### DIFF
--- a/cohort/scripts/query_request_updater.py
+++ b/cohort/scripts/query_request_updater.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import tempfile
+from dataclasses import dataclass
 from functools import reduce
 from pathlib import Path
 from typing import List, Tuple, TypeVar, Callable, Any, Optional, Dict, Union
@@ -13,6 +14,12 @@ logger = logging.getLogger(__name__)
 
 RESOURCE_DEFAULT = "_"
 MATCH_ALL_VALUES = "__MATCH_ALL_VALUES__"
+
+
+@dataclass
+class _FilterQuerySnapshot:
+    filter_uuid: Any
+    serialized_query: str
 
 
 def find_mapped_code(
@@ -120,7 +127,7 @@ class QueryRequestUpdater:
         changed = False
         for filter_item in filter_items:
             if filter_item.strip():
-                filter_name, filter_value = filter_item.split("=")
+                filter_name, filter_value = filter_item.split("=", 1)
                 if not self.skip_filter(filter_name, resource):
                     new_filter_name, has_changed = self.map_filter_name(filter_name, resource)
                     new_filter_value, value_changed = self.map_filter_value(filter_name, resource, filter_value)
@@ -268,9 +275,9 @@ class QueryRequestUpdater:
         if with_filters:
             self.update_old_filters(dry_run, debug)
 
-    def save_filter(self, f: RequestQuerySnapshot, filters: List[FhirFilter]):
+    def save_filter(self, f: _FilterQuerySnapshot, filters: List[FhirFilter]):
         for resource_filter in filters:
-            if resource_filter.uuid == f.title:
+            if resource_filter.uuid == f.filter_uuid:
                 query = json.loads(f.serialized_query)
                 resource_filter.query_version = query.get("version", self.version_name)
                 resource_filter.filter = query["fhirFilter"]
@@ -282,8 +289,8 @@ class QueryRequestUpdater:
         all_filters: List[FhirFilter] = FhirFilter.objects.all()
         self.do_update_old_query_snapshots(
             [
-                RequestQuerySnapshot(
-                    title=f.uuid,
+                _FilterQuerySnapshot(
+                    filter_uuid=f.uuid,
                     serialized_query=json.dumps(
                         {"version": f.query_version, "_type": "resource", "resourceType": f.fhir_resource, "fhirFilter": f.filter}
                     ),

--- a/cohort/tests/test_query_request_updater.py
+++ b/cohort/tests/test_query_request_updater.py
@@ -1,7 +1,9 @@
 import dataclasses
 import json
+from unittest.mock import patch
 
 from admin_cohort.tests.tests_tools import BaseTests
+from cohort.scripts import query_request_updater as query_request_updater_module
 from cohort.scripts.patch_requests_v145 import return_filter_if_not_exist
 from cohort.scripts.patch_requests_v162 import CCAM_OLD_CODESYSTEM, map_ccam_code_token, map_ccam_codes, updater_v162
 from cohort.scripts.patch_requests_v163 import replace_ccam_root_with_match_all, updater
@@ -11,6 +13,41 @@ CCAM = "https://aphp.fr/ig/fhir/core/CodeSystem/CCAMDescriptiveVerAPHP"
 
 
 class TestQueryRequestUpdater(BaseTests):
+    def test_filter_value_can_contain_equals_signs(self):
+        updater = QueryRequestUpdater(
+            version_name="2",
+            previous_version_name="1",
+            filter_mapping={},
+            filter_names_to_skip={},
+            filter_values_mapping={},
+            static_required_filters={},
+            resource_name_mapping={},
+        )
+
+        updated_filter, changed = updater.process_filters(["SomeFilter=SomeValue=WithEquals"], "SomeResource")
+
+        self.assertEqual("SomeFilter=SomeValue=WithEquals", updated_filter)
+        self.assertFalse(changed)
+
+    def test_update_old_filters_does_not_build_request_query_snapshot(self):
+        updater = QueryRequestUpdater(
+            version_name="2",
+            previous_version_name="1",
+            filter_mapping={"SomeResource": {"SomeFilterA": "SomeFilterB"}},
+            filter_names_to_skip={},
+            filter_values_mapping={},
+            static_required_filters={},
+            resource_name_mapping={},
+        )
+        resource_filter = Filter(uuid="filter-uuid", query_version="1", fhir_resource="SomeResource", filter="SomeFilterA=SomeValue")
+
+        with patch.object(query_request_updater_module.FhirFilter.objects, "all", return_value=[resource_filter]):
+            updater.update_old_filters(dry_run=False, debug=False)
+
+        self.assertEqual("2", resource_filter.query_version)
+        self.assertEqual("SomeFilterB=SomeValue", resource_filter.filter)
+        self.assertTrue(resource_filter.saved)
+
     def test_update_old_query_snapshots(self):
         new_version = "turbo2000"
         previous_version_name = "1"
@@ -98,6 +135,18 @@ class TestQueryRequestUpdater(BaseTests):
 @dataclasses.dataclass
 class Request:
     serialized_query: str
+
+
+@dataclasses.dataclass
+class Filter:
+    uuid: str
+    query_version: str
+    fhir_resource: str
+    filter: str
+    saved: bool = False
+
+    def save(self):
+        self.saved = True
 
 
 class TestPatchRequestsV162(BaseTests):


### PR DESCRIPTION
## Contexte

Le dry-run du patch v1.6.2 échoue sur deux cas présents en préproduction :

- certaines valeurs de filtres contiennent plusieurs caractères = ;
- la mise à jour des FhirFilter construit un RequestQuerySnapshot avec le champ supprimé title.

## Modifications

- limite le découpage des filtres au premier caractère = avec split(=, 1) ;
- remplace le faux modèle Django par un objet interne dédié contenant l’UUID du filtre et la requête sérialisée ;
- ajoute deux tests de non-régression couvrant ces erreurs.

## Impact

Le patch peut traiter les requêtes contenant un = dans leur valeur et mettre à jour les filtres sauvegardés avec le modèle Django actuel.

## Validation

Aucun formatage ni test local exécuté à la demande du demandeur. La validation est confiée à la CI.