### PR TITLE
fix: preserve request filter fragments without equals

### DIFF
--- a/cohort/scripts/query_request_updater.py
+++ b/cohort/scripts/query_request_updater.py
@@ -127,6 +127,9 @@ class QueryRequestUpdater:
         changed = False
         for filter_item in filter_items:
             if filter_item.strip():
+                if "=" not in filter_item:
+                    updated_filters.append(filter_item)
+                    continue
                 filter_name, filter_value = filter_item.split("=", 1)
                 if not self.skip_filter(filter_name, resource):
                     new_filter_name, has_changed = self.map_filter_name(filter_name, resource)

--- a/cohort/tests/test_query_request_updater.py
+++ b/cohort/tests/test_query_request_updater.py
@@ -13,6 +13,24 @@ CCAM = "https://aphp.fr/ig/fhir/core/CodeSystem/CCAMDescriptiveVerAPHP"
 
 
 class TestQueryRequestUpdater(BaseTests):
+    def test_filter_fragment_without_equals_sign_is_preserved(self):
+        updater = QueryRequestUpdater(
+            version_name="2",
+            previous_version_name="1",
+            filter_mapping={},
+            filter_names_to_skip={},
+            filter_values_mapping={},
+            static_required_filters={},
+            resource_name_mapping={},
+        )
+        original_filter = "code=https://example.org/CodeSystem/observation|123&urn:oid:1.2.3|456,urn:oid:1.2.4|789"
+        resource = {"resourceType": "Observation", "fhirFilter": original_filter}
+
+        changed = updater.process_resource(resource, "fhirFilter")
+
+        self.assertEqual(original_filter, resource["fhirFilter"])
+        self.assertFalse(changed)
+
     def test_filter_value_can_contain_equals_signs(self):
         updater = QueryRequestUpdater(
             version_name="2",


### PR DESCRIPTION
## Contexte

Le dry-run puis l’exécution du patch v1.6.2 ont laissé trois snapshots Observation en v1.6.1. Leur filtre contient un fragment séparé par & sans caractère =, alors que QueryRequestUpdater supposait que chaque fragment respectait la forme nom=valeur.

## Cause racine

process_filters appelait systématiquement split(=, 1). Les fragments sans séparateur levaient donc ValueError et empêchaient la montée de version du snapshot complet.

## Modifications

- préserve à l’identique tout fragment non vide ne contenant pas = ;
- poursuit le traitement des autres filtres ;
- ajoute un test de non-régression end-to-end sur une ressource Observation.

## Impact

Les trois snapshots concernés pourront être retraités par v1.6.2 sans altération de leur filtre Observation.

## Validation

Aucun formatage ni test local exécuté à la demande du demandeur. La validation est confiée à la CI.