### PR TITLE
fix(influxdb): use certifi CA bundle for TLS

### DIFF
--- a/admin_cohort/middleware/influxdb_middleware.py
+++ b/admin_cohort/middleware/influxdb_middleware.py
@@ -1,4 +1,6 @@
 from time import time
+
+import certifi
 from influxdb_client import InfluxDBClient
 from influxdb_client.client.write_api import ASYNCHRONOUS
 
@@ -8,7 +10,11 @@ from django.conf import settings
 class InfluxDBMiddleware:
     def __init__(self, get_response):
         self.get_response = get_response
-        self.client = InfluxDBClient(url=settings.INFLUXDB_URL, token=settings.INFLUXDB_TOKEN)
+        self.client = InfluxDBClient(
+            url=settings.INFLUXDB_URL,
+            token=settings.INFLUXDB_TOKEN,
+            ssl_ca_cert=certifi.where(),
+        )
 
     def __call__(self, request):
         if not settings.INFLUXDB_ENABLED:

--- a/admin_cohort/services/health.py
+++ b/admin_cohort/services/health.py
@@ -4,6 +4,7 @@ import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Callable, Optional
 
+import certifi
 import requests
 from django.apps import apps
 from django.conf import settings
@@ -144,6 +145,7 @@ def _check_influxdb() -> Optional[str]:
         url=settings.INFLUXDB_URL,
         token=settings.INFLUXDB_TOKEN,
         org=settings.INFLUXDB_ORG,
+        ssl_ca_cert=certifi.where(),
         timeout=int(CHECK_TIMEOUT_SECONDS * 1000),
     )
     try:

--- a/admin_cohort/tests/test_health.py
+++ b/admin_cohort/tests/test_health.py
@@ -178,6 +178,13 @@ class IndividualChecksTests(SimpleTestCase):
         client.ping.return_value = True
         mock_client_cls.return_value = client
         self.assertIsNone(_check_influxdb())
+        mock_client_cls.assert_called_once_with(
+            url="http://x",
+            token="t",
+            org="o",
+            ssl_ca_cert=health_module.certifi.where(),
+            timeout=2000,
+        )
         client.close.assert_called_once()
 
     @override_settings(INFLUXDB_ENABLED=True, INFLUXDB_URL="http://x", INFLUXDB_TOKEN="t", INFLUXDB_ORG="o")

--- a/admin_cohort/tests/test_influxdb_middleware.py
+++ b/admin_cohort/tests/test_influxdb_middleware.py
@@ -1,0 +1,19 @@
+from unittest.mock import patch
+
+import certifi
+from django.test import SimpleTestCase, override_settings
+
+from admin_cohort.middleware.influxdb_middleware import InfluxDBMiddleware
+
+
+class InfluxDBMiddlewareTests(SimpleTestCase):
+    @override_settings(INFLUXDB_URL="https://influx.example", INFLUXDB_TOKEN="token")
+    @patch("admin_cohort.middleware.influxdb_middleware.InfluxDBClient")
+    def test_client_uses_certifi_ca_bundle(self, mock_client_cls):
+        InfluxDBMiddleware(lambda request: None)
+
+        mock_client_cls.assert_called_once_with(
+            url="https://influx.example",
+            token="token",
+            ssl_ca_cert=certifi.where(),
+        )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
     "asgiref>=3.8",
+    "certifi>=2024.8.30",
     "channels-redis>=4.2.1",
     "channels>=4.2.0",
     "coverage>=7.6.9",

--- a/uv.lock
+++ b/uv.lock
@@ -409,6 +409,7 @@ source = { virtual = "." }
 dependencies = [
     { name = "asgiref" },
     { name = "celery" },
+    { name = "certifi" },
     { name = "channels" },
     { name = "channels-redis" },
     { name = "coverage" },
@@ -461,6 +462,7 @@ dev = [
 requires-dist = [
     { name = "asgiref", specifier = ">=3.8" },
     { name = "celery", specifier = ">=5.4.0" },
+    { name = "certifi", specifier = ">=2024.8.30" },
     { name = "channels", specifier = ">=4.2.0" },
     { name = "channels-redis", specifier = ">=4.2.1" },
     { name = "coverage", specifier = ">=7.6.9" },


### PR DESCRIPTION
## Objectif
Corriger le health check InfluxDB de l’API Django en production, qui retournait `ping returned false`, et rétablir une configuration TLS fonctionnelle pour les écritures de métriques.

La préproduction retournait `ok=true, skipped=true` car `INFLUXDB_ENABLED=False` : elle ne testait donc pas réellement InfluxDB. En production, `INFLUXDB_ENABLED=True` déclenchait `InfluxDBClient.ping()`, qui échouait sur la validation du certificat TLS.

Le diagnostic effectué depuis les trois pods Django de production a montré :

- une résolution DNS et une connectivité réseau fonctionnelles vers `influx.eds.aphp.fr` ;
- un échec TLS `CERTIFICATE_VERIFY_FAILED: unable to get local issuer certificate` ;
- un trust store système ancien dans l’image (`ca-certificates 20210119`) qui ne contient pas la racine `HARICA TLS RSA Root CA 2021` ;
- la présence de cette racine dans le bundle `certifi` déjà utilisé par l’environnement Python.

## Changements réalisés
- Déclaration explicite de la dépendance `certifi>=2024.8.30` et mise à jour de `uv.lock`.
- Utilisation explicite de `certifi.where()` via `ssl_ca_cert` dans le client du health check InfluxDB.
- Application de la même configuration au client du middleware InfluxDB afin de corriger également les écritures de métriques.
- Ajout d’assertions de non-régression sur la configuration TLS du health check.
- Ajout d’un test unitaire dédié à l’initialisation du client InfluxDB du middleware.

La vérification TLS reste activée : aucun `verify_ssl=False` ni contournement de sécurité n’est introduit.

## Impacts
- **Back** : le contrôle InfluxDB de `/health` peut valider correctement le certificat présenté par `influx.eds.aphp.fr`.
- **Observabilité** : les écritures asynchrones du middleware utilisent le même bundle CA corrigé.
- **API** : aucun changement de contrat ou de format de réponse.
- **DB / droits / exports / jobs** : aucun impact.
- **Sécurité** : amélioration ciblée de la chaîne de confiance TLS, sans désactivation de la vérification.
- **Performance** : impact négligeable ; le bundle CA est uniquement fourni à l’initialisation du client.

## Tests réalisés
- `uv lock --check` : succès.
- Ruff sur les fichiers modifiés : succès, aucune erreur.
- Validation syntaxique Python des fichiers modifiés : succès.
- Validation manuelle depuis un pod Django prod avec la configuration proposée : `verify_ssl=true` et `ping=true`.
- Vérification sans validation TLS uniquement pendant le diagnostic : InfluxDB répondait `/ping` en HTTP 204 et `/health` en HTTP 200 avec le statut `pass`.

La suite pytest ciblée n’a pas pu démarrer sur le poste Windows : la dépendance native existante `krb5==0.7.0` requiert `krb5-config`, indisponible dans cet environnement. Docker n’a pas été utilisé en raison des ressources locales disponibles. Les tests ajoutés devront donc également être exécutés par la CI Linux.

## Risques
- La correction dépend du bundle CA fourni par `certifi`, désormais déclaré explicitement et verrouillé dans `uv.lock`.
- Les tests pytest complets restent à confirmer par la CI Linux.
- La préproduction ne vérifiera réellement InfluxDB que lorsque `INFLUXDB_ENABLED=True` y sera déployé.
- Aucun changement n’est apporté aux probes Kubernetes, qui continuent actuellement d’interroger `/docs` plutôt que `/health`.
