### PR TITLE
fix(query): add root wildcard to segmented CCAM codes (3388)

### DIFF
--- a/cohort/scripts/patch_requests_v164.py
+++ b/cohort/scripts/patch_requests_v164.py
@@ -1,0 +1,71 @@
+import re
+
+from cohort.scripts.patch_requests_v163 import NEW_VERSION as PREV_VERSION
+from cohort.scripts.query_request_updater import MATCH_ALL_VALUES, QueryRequestUpdater
+
+NEW_VERSION = "v1.6.4"
+
+# Racine d'un acte, avant segmentation par activité. Cf. guide de lecture CCAM, page 25, section 3.1 :
+# https://www.atih.sante.fr/sites/default/files/public/content/1678/guide_lecture_complet_01082008.pdf
+CCAM_LEAF_ROOT_RE = re.compile(r"^([A-Z]{4}[0-9]{3})")
+
+CCAM_CODESYSTEMS = frozenset(
+    {
+        "https://www.atih.sante.fr/plateformes-de-transmission-et-logiciels/logiciels-espace-de-telechargement/id_lot/3550",
+        "https://aphp.fr/ig/fhir/core/CodeSystem/CCAMDescriptiveVerAPHP",
+        "https://terminology.eds.aphp.fr/aphp-orbis-ccam",
+    }
+)
+
+
+def root_prefix_token(token: str) -> str | None:
+    if not token or token.endswith("*"):
+        return None
+    system, sep, code = token.rpartition("|")
+    if sep and system not in CCAM_CODESYSTEMS:
+        return None
+    root = CCAM_LEAF_ROOT_RE.match(code)
+    if not root:
+        return None
+    return f"{system}{sep}{root.group(1)}*"
+
+
+def map_ccam_codes(codes: str) -> str:
+    # Les codes déjà sélectionnés sont conservés : ce sont eux qui restent cochés dans le requêteur.
+    mapped: list[str] = []
+    for raw_token in codes.split(","):
+        token = raw_token.strip()
+        if not token:
+            continue
+        root = root_prefix_token(token)
+        # Un acte nu n'existe plus dans le référentiel, le joker le remplace au lieu de s'y ajouter.
+        if root and CCAM_LEAF_ROOT_RE.fullmatch(token.rpartition("|")[2]):
+            token = root
+            root = None
+        if token not in mapped:
+            mapped.append(token)
+        if root and root not in mapped:
+            mapped.append(root)
+    return ",".join(mapped)
+
+
+FILTER_MAPPING = {}
+
+FILTER_NAME_TO_SKIP = {}
+
+FILTER_VALUE_MAPPING = {"Procedure": {"code": {MATCH_ALL_VALUES: map_ccam_codes}}}
+
+STATIC_REQUIRED_FILTERS = {}
+
+RESOURCE_NAME_MAPPING = {}
+
+
+updater_v164 = QueryRequestUpdater(
+    version_name=NEW_VERSION,
+    previous_version_name=[PREV_VERSION],
+    filter_mapping=FILTER_MAPPING,
+    filter_names_to_skip=FILTER_NAME_TO_SKIP,
+    filter_values_mapping=FILTER_VALUE_MAPPING,
+    static_required_filters=STATIC_REQUIRED_FILTERS,
+    resource_name_mapping=RESOURCE_NAME_MAPPING,
+)

--- a/cohort/tests/test_query_request_updater.py
+++ b/cohort/tests/test_query_request_updater.py
@@ -7,6 +7,7 @@ from cohort.scripts import query_request_updater as query_request_updater_module
 from cohort.scripts.patch_requests_v145 import return_filter_if_not_exist
 from cohort.scripts.patch_requests_v162 import CCAM_OLD_CODESYSTEM, map_ccam_code_token, map_ccam_codes, updater_v162
 from cohort.scripts.patch_requests_v163 import replace_ccam_root_with_match_all, updater
+from cohort.scripts.patch_requests_v164 import map_ccam_codes as map_ccam_codes_v164, updater_v164
 from cohort.scripts.query_request_updater import QueryRequestUpdater
 
 CCAM = "https://aphp.fr/ig/fhir/core/CodeSystem/CCAMDescriptiveVerAPHP"
@@ -233,3 +234,53 @@ class TestPatchRequestsV163(BaseTests):
         result = json.loads(saved[0])
         self.assertEqual("v1.6.3", result["version"])
         self.assertEqual("code=*", result["fhirFilter"])
+
+
+class TestPatchRequestsV164(BaseTests):
+    def test_bare_act_is_replaced_by_root_wildcard(self):
+        self.assertEqual(f"{CCAM}|JQGA004*", map_ccam_codes_v164(f"{CCAM}|JQGA004"))
+
+    def test_segmented_act_is_kept_and_completed(self):
+        self.assertEqual(f"{CCAM}|JQGA004...01,{CCAM}|JQGA004*", map_ccam_codes_v164(f"{CCAM}|JQGA004...01"))
+        self.assertEqual(f"{CCAM}|JQGA004-001,{CCAM}|JQGA004*", map_ccam_codes_v164(f"{CCAM}|JQGA004-001"))
+
+    def test_truncated_selection_keeps_both_codes(self):
+        codes = f"{CCAM}|JQGA004...04,{CCAM}|JQGA004...01"
+        expected = f"{CCAM}|JQGA004...04,{CCAM}|JQGA004*,{CCAM}|JQGA004...01"
+        self.assertEqual(expected, map_ccam_codes_v164(codes))
+
+    def test_distinct_acts_get_their_own_wildcard(self):
+        codes = f"{CCAM}|JQGA004...01,{CCAM}|HGEA002-1101"
+        expected = f"{CCAM}|JQGA004...01,{CCAM}|JQGA004*,{CCAM}|HGEA002-1101,{CCAM}|HGEA002*"
+        self.assertEqual(expected, map_ccam_codes_v164(codes))
+
+    def test_numeric_node_untouched(self):
+        self.assertEqual(f"{CCAM}|001472", map_ccam_codes_v164(f"{CCAM}|001472"))
+
+    def test_match_all_untouched(self):
+        self.assertEqual("*", map_ccam_codes_v164("*"))
+
+    def test_non_ccam_system_untouched(self):
+        other = "https://terminology.hl7.org/CodeSystem/other"
+        self.assertEqual(f"{other}|JQGA004", map_ccam_codes_v164(f"{other}|JQGA004"))
+
+    def test_is_idempotent(self):
+        once = map_ccam_codes_v164(f"{CCAM}|JQGA004...01")
+        self.assertEqual(once, map_ccam_codes_v164(once))
+
+    def test_end_to_end_procedure_criteria(self):
+        query = {
+            "version": "v1.6.3",
+            "_type": "resource",
+            "resourceType": "Procedure",
+            "fhirFilter": f"subject.active=true&code={CCAM}|JQGA004...04,{CCAM}|JQGA004...01",
+        }
+        saved = []
+        updater_v164.do_update_old_query_snapshots(
+            [Request(json.dumps(query))], lambda r: saved.append(r.serialized_query), dry_run=False, debug=False
+        )
+        self.assertEqual(1, len(saved))
+        result = json.loads(saved[0])
+        self.assertEqual("v1.6.4", result["version"])
+        expected = f"subject.active=true&code={CCAM}|JQGA004...04,{CCAM}|JQGA004*,{CCAM}|JQGA004...01"
+        self.assertEqual(expected, result["fhirFilter"])


### PR DESCRIPTION
## Objectif
Les requêtes créées avant la segmentation des codes CCAM par activité ne couvrent plus qu'une partie des déclinaisons de chaque acte : les codes au format tiret sont absents des requêtes migrées.
Fixes https://gitlab.data.aphp.fr/ID/design-et-produit/ipa/cohort360/gestion-de-projet/-/work_items/3388
Related to https://gitlab.data.aphp.fr/ID/design-et-produit/ipa/cohort360/gestion-de-projet/-/work_items/3371

## Changements réalisés
Script de migration `patch_requests_v164` : chaque code d'acte CCAM présent dans une requête reçoit le joker sur sa racine de 7 caractères, ce qui couvre les déclinaisons quel que soit leur format. Les codes déjà sélectionnés sont conservés, un acte nu est remplacé par son joker. Nœuds numériques, `*` global et systèmes non CCAM inchangés.

## Impacts
DB : réécriture des `serialized_query` en v1.6.4. Nécessite le front en v1.6.4.

## Tests réalisés
Unitaires.

## Risques
À lancer après le déploiement du front, sinon les requêtes migrées sont retronquées à l'ouverture. Le comportement du moteur sur une étoile stockée dans le `filterFhir` reste à valider en préprod avant le passage en prod.
