### PR TITLE
fix(exports): stream le download ZIP sans buffering (coupure ~1Go)

### DIFF
--- a/.conf/gunicorn.conf.py
+++ b/.conf/gunicorn.conf.py
@@ -9,6 +9,7 @@ env = environ.Env()
 workers = 7
 threads = 10
 limit_request_line = 8190
+timeout = 1800
 
 
 class CustomLogger(Logger):

--- a/.conf/nginx.conf
+++ b/.conf/nginx.conf
@@ -91,6 +91,19 @@ http {
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         }
 
+        location ~ ^/exports/[^/]+/download/?$ {
+            proxy_pass http://backend;
+            proxy_set_header Host {{BACKEND_HOST}};
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+
+            # Streamed multi-GB export, do not spool to a temp file
+            proxy_buffering off;
+            proxy_max_temp_file_size 0;
+            proxy_read_timeout 3600s;
+            proxy_send_timeout 3600s;
+        }
+
         location / {
             proxy_pass http://backend;
             proxy_set_header Host {{BACKEND_HOST}};


### PR DESCRIPTION
## Objectif
Le download du ZIP d'un export coupe à ~1Go dès que le fichier est plus gros (HTTP/2 INTERNAL_ERROR), archive inutilisable.

## Changements réalisés
location dédiée à `exports/<id>/download/` en pass-through (proxy_buffering off, proxy_max_temp_file_size 0, read/send timeout 3600s). timeout gunicorn à 1800.

## Impacts
Exports.

## Tests réalisés
nginx -t.

## Risques
Config bakée dans l'image : effective au prochain build/déploiement, pas en reload à chaud.