### PR TITLE
fix(exports): sécuriser et rendre reprenable le streaming des exports

### DIFF
--- a/.conf/nginx.conf
+++ b/.conf/nginx.conf
@@ -11,11 +11,11 @@ events {
 http {
 
     upstream backend {
-        server localhost:8000;
+        server 127.0.0.1:8000;
     }
 
     upstream channels-backend {
-        server localhost:8005;
+        server 127.0.0.1:8005;
     }
 
 	##

--- a/admin_cohort/settings.py
+++ b/admin_cohort/settings.py
@@ -346,6 +346,8 @@ CACHES = {"default": {"BACKEND": "django_redis.cache.RedisCache", "LOCATION": CE
 if not env.bool("ENABLE_CACHE", default=False):
     CACHES = {"default": {"BACKEND": "admin_cohort.tools.cache.CustomDummyCache"}}
 
+EXPORT_DOWNLOAD_TICKET_TTL_SECONDS = env.int("EXPORT_DOWNLOAD_TICKET_TTL_SECONDS", default=60)
+
 REST_FRAMEWORK_EXTENSIONS = {
     "DEFAULT_PARENT_LOOKUP_KWARG_NAME_PREFIX": "",
     "DEFAULT_USE_CACHE": "default",

--- a/exports/exceptions.py
+++ b/exports/exceptions.py
@@ -10,5 +10,17 @@ class StorageProviderException(Exception):
     pass
 
 
+class InvalidDownloadTicket(Exception):
+    pass
+
+
+class DownloadTicketUnavailable(Exception):
+    pass
+
+
+class InvalidRangeError(Exception):
+    pass
+
+
 class HdfsServerUnreachable(Exception):
     pass

--- a/exports/services/download_ticket.py
+++ b/exports/services/download_ticket.py
@@ -1,0 +1,48 @@
+import hashlib
+import secrets
+
+from django.conf import settings
+from django.core.cache import cache
+
+from exports.exceptions import DownloadTicketUnavailable, InvalidDownloadTicket
+
+
+class ExportDownloadTicketService:
+    cache_prefix = "export-download-ticket"
+    cookie_prefix = "export_download_ticket_"
+
+    @property
+    def ttl_seconds(self) -> int:
+        return settings.EXPORT_DOWNLOAD_TICKET_TTL_SECONDS
+
+    @staticmethod
+    def cookie_name(export_uuid) -> str:
+        return f"{ExportDownloadTicketService.cookie_prefix}{str(export_uuid).replace('-', '')}"
+
+    def issue(self, export_uuid, user_id) -> str:
+        token = secrets.token_urlsafe(32)
+        key = self._ticket_key(token)
+        payload = {"export_uuid": str(export_uuid), "user_id": str(user_id)}
+        cache.set(key, payload, timeout=self.ttl_seconds)
+        if cache.get(key) != payload:
+            raise DownloadTicketUnavailable("The shared download ticket cache is unavailable")
+        return token
+
+    def consume(self, token: str, expected_export_uuid) -> dict:
+        key = self._ticket_key(token)
+        payload = cache.get(key)
+        if payload is None or payload.get("export_uuid") != str(expected_export_uuid):
+            raise InvalidDownloadTicket("The download ticket is invalid or expired")
+
+        claimed_key = f"{key}:claimed"
+        if not cache.add(claimed_key, True, timeout=self.ttl_seconds):
+            raise InvalidDownloadTicket("The download ticket has already been used")
+        cache.delete(key)
+        return payload
+
+    def _ticket_key(self, token: str) -> str:
+        digest = hashlib.sha256(token.encode("utf-8")).hexdigest()
+        return f"{self.cache_prefix}:{digest}"
+
+
+export_download_ticket_service = ExportDownloadTicketService()

--- a/exports/services/export.py
+++ b/exports/services/export.py
@@ -164,8 +164,8 @@ class ExportService:
         launch_export_task.delay(export.pk)
 
     @staticmethod
-    def download(export: Export) -> StreamingHttpResponse:
-        return ExportDownloader().download(export=export)
+    def download(export: Export, range_header: str | None = None) -> StreamingHttpResponse:
+        return ExportDownloader().download(export=export, range_header=range_header)
 
     @staticmethod
     def retry(export: Export):

--- a/exports/services/export_operators.py
+++ b/exports/services/export_operators.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import re
 from datetime import timedelta
 
 from django.conf import settings
@@ -12,7 +13,7 @@ from requests import RequestException
 from admin_cohort.types import JobStatus
 from exports.apps import ExportsConfig
 from exports.emails import push_email_notification, exported_files_deleted
-from exports.exceptions import BadRequestError, FilesNoLongerAvailable, StorageProviderException
+from exports.exceptions import BadRequestError, FilesNoLongerAvailable, InvalidRangeError, StorageProviderException
 from exports.models import Export
 from exports.services.storage_provider import HDFSStorageProvider
 
@@ -92,33 +93,71 @@ class DefaultExporter:
 
 
 class ExportDownloader:
+    range_pattern = re.compile(r"^bytes=(\d*)-(\d*)$")
+
     def __init__(self):
         self.storage_provider = HDFSStorageProvider(servers_urls=STORAGE_PROVIDERS)
         self.downloadable_export_types = [t.value for t in ExportTypes if t.allow_download]
 
-    def download(self, export: Export) -> StreamingHttpResponse:
+    def download(self, export: Export, range_header: str | None = None) -> StreamingHttpResponse:
         if export.request_job_status != JobStatus.finished.value or export.output_format not in self.downloadable_export_types:
             raise BadRequestError("The export is not done yet or has failed or not downloadable")
         if not export.available_for_download():
             raise FilesNoLongerAvailable("The exported files are no longer available on the server.")
         try:
             file_path = f"{export.target_full_path}.zip"
-            response = StreamingHttpResponse(streaming_content=self.stream_file(file_path))
             file_size = self.get_file_size(file_name=file_path)
+            start, end = self.parse_range(range_header=range_header, file_size=file_size)
+            content_length = end - start + 1
+            response = StreamingHttpResponse(
+                streaming_content=self.stream_file(file_path, offset=start, length=content_length),
+                status=206 if range_header else 200,
+            )
             first = export.export_tables.first()
             if first is None or first.cohort_result_source is None:
                 raise BadRequestError("Export has no table with cohort result source")
             download_file_name = f"export_{first.cohort_result_source.group_id}.zip"
             response["Content-Type"] = "application/zip"
-            response["Content-Length"] = file_size
+            response["Content-Length"] = content_length
             response["Content-Disposition"] = f"attachment; filename={download_file_name}"
+            response["Accept-Ranges"] = "bytes"
+            response["X-Accel-Buffering"] = "no"
+            if range_header:
+                response["Content-Range"] = f"bytes {start}-{end}/{file_size}"
             return response
         except StorageProviderException as e:
             logger.exception(f"Error occurred on Storage Provider `{self.storage_provider.name}` - {e}")
             raise e
 
-    def stream_file(self, file_name: str):
-        with self.storage_provider.stream_file(file_name=file_name) as f:
+    def parse_range(self, range_header: str | None, file_size: int) -> tuple[int, int]:
+        if not range_header:
+            return 0, file_size - 1
+
+        match = self.range_pattern.fullmatch(range_header.strip())
+        if match is None or file_size <= 0:
+            raise InvalidRangeError("Invalid byte range")
+
+        start_raw, end_raw = match.groups()
+        if not start_raw and not end_raw:
+            raise InvalidRangeError("Invalid byte range")
+
+        if not start_raw:
+            suffix_length = int(end_raw)
+            if suffix_length <= 0:
+                raise InvalidRangeError("Invalid byte range")
+            start = max(file_size - suffix_length, 0)
+            end = file_size - 1
+        else:
+            start = int(start_raw)
+            end = int(end_raw) if end_raw else file_size - 1
+            end = min(end, file_size - 1)
+
+        if start >= file_size or start > end:
+            raise InvalidRangeError("Requested byte range is outside the file")
+        return start, end
+
+    def stream_file(self, file_name: str, offset: int = 0, length: int | None = None):
+        with self.storage_provider.stream_file(file_name=file_name, offset=offset, length=length) as f:
             for chunk in f:
                 yield chunk
 

--- a/exports/services/storage_provider.py
+++ b/exports/services/storage_provider.py
@@ -28,7 +28,7 @@ class StorageProvider:
         """
         raise NotImplementedError
 
-    def stream_file(self, file_name: str):
+    def stream_file(self, file_name: str, offset: int = 0, length: int | None = None):
         """
         read and stream a file from the storage provider
         @param file_name: file to be streamed
@@ -74,8 +74,16 @@ class HDFSStorageProvider(StorageProvider):
         return self.client.status(hdfs_path=file_name).get("length")
 
     @catch_hdfs_error
-    def stream_file(self, file_name: str):
-        return self.client.read(hdfs_path=file_name, offset=0, length=None, encoding=None, chunk_size=1000000, delimiter=None, progress=None)
+    def stream_file(self, file_name: str, offset: int = 0, length: int | None = None):
+        return self.client.read(
+            hdfs_path=file_name,
+            offset=offset,
+            length=length,
+            encoding=None,
+            chunk_size=1000000,
+            delimiter=None,
+            progress=None,
+        )
 
     @catch_hdfs_error
     def delete_file(self, file_name: str):

--- a/exports/tests/test_download_ticket.py
+++ b/exports/tests/test_download_ticket.py
@@ -1,0 +1,36 @@
+from django.core.cache import cache
+from django.test import SimpleTestCase, override_settings
+
+from exports.exceptions import DownloadTicketUnavailable, InvalidDownloadTicket
+from exports.services.download_ticket import ExportDownloadTicketService
+
+
+LOC_MEM_CACHE = {"default": {"BACKEND": "django.core.cache.backends.locmem.LocMemCache", "LOCATION": "export-download-tickets"}}
+DUMMY_CACHE = {"default": {"BACKEND": "admin_cohort.tools.cache.CustomDummyCache"}}
+
+
+@override_settings(CACHES=LOC_MEM_CACHE, EXPORT_DOWNLOAD_TICKET_TTL_SECONDS=60)
+class ExportDownloadTicketServiceTest(SimpleTestCase):
+    def setUp(self):
+        cache.clear()
+        self.service = ExportDownloadTicketService()
+
+    def test_ticket_is_bound_to_export_and_single_use(self):
+        token = self.service.issue(export_uuid="export-1", user_id="user-1")
+
+        payload = self.service.consume(token=token, expected_export_uuid="export-1")
+
+        self.assertEqual(payload, {"export_uuid": "export-1", "user_id": "user-1"})
+        with self.assertRaises(InvalidDownloadTicket):
+            self.service.consume(token=token, expected_export_uuid="export-1")
+
+    def test_ticket_cannot_be_used_for_another_export(self):
+        token = self.service.issue(export_uuid="export-1", user_id="user-1")
+
+        with self.assertRaises(InvalidDownloadTicket):
+            self.service.consume(token=token, expected_export_uuid="export-2")
+
+    @override_settings(CACHES=DUMMY_CACHE)
+    def test_ticket_creation_fails_closed_without_shared_cache(self):
+        with self.assertRaises(DownloadTicketUnavailable):
+            self.service.issue(export_uuid="export-1", user_id="user-1")

--- a/exports/tests/test_export_downloader.py
+++ b/exports/tests/test_export_downloader.py
@@ -8,7 +8,7 @@ from rest_framework import status
 
 from admin_cohort.types import JobStatus
 from exports.apps import ExportsConfig
-from exports.exceptions import BadRequestError, FilesNoLongerAvailable
+from exports.exceptions import BadRequestError, FilesNoLongerAvailable, InvalidRangeError
 from exports.models import Export, ExportTable
 from exports.services.export_operators import ExportDownloader
 from exports.tests.test_view_export_request import ExportsTests
@@ -41,7 +41,32 @@ class TestExportDownloader(ExportsTests):
             mock_file.__iter__.return_value = iter(["chunk1", "chunk2"])
             response = self.export_downloader.download(self.export1)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response["Content-Length"], "11111")
+        self.assertEqual(response["Accept-Ranges"], "bytes")
+        self.assertEqual(response["X-Accel-Buffering"], "no")
         self.mock_storage_provider.get_file_size.assert_called_once()
+
+    def test_download_export_byte_range(self):
+        self.mock_storage_provider.get_file_size.return_value = 1000
+        mock_file = MagicMock()
+        mock_file.__iter__.return_value = iter([b"partial"])
+        self.mock_storage_provider.stream_file.return_value.__enter__.return_value = mock_file
+
+        response = self.export_downloader.download(self.export1, range_header="bytes=100-199")
+        list(response.streaming_content)
+
+        self.assertEqual(response.status_code, status.HTTP_206_PARTIAL_CONTENT)
+        self.assertEqual(response["Content-Length"], "100")
+        self.assertEqual(response["Content-Range"], "bytes 100-199/1000")
+        self.mock_storage_provider.stream_file.assert_called_once_with(
+            file_name=f"{self.export1.target_full_path}.zip", offset=100, length=100
+        )
+
+    def test_rejects_invalid_byte_range(self):
+        self.mock_storage_provider.get_file_size.return_value = 1000
+
+        with self.assertRaises(InvalidRangeError):
+            self.export_downloader.download(self.export1, range_header="bytes=1000-")
 
     def test_error_download_export_type_plain(self):
         self.export1.output_format = "bad_format"

--- a/exports/tests/test_view_export.py
+++ b/exports/tests/test_view_export.py
@@ -1,6 +1,7 @@
 from unittest import mock
 
 from django.test.utils import override_settings
+from django.http import StreamingHttpResponse
 from django.urls import reverse
 from requests.exceptions import RequestException
 from rest_framework import status
@@ -13,6 +14,12 @@ from exporters.enums import APIJobStatus
 from exports.models import Export, Datalab
 from exports.tests.base_test import ExportsTestBase
 from exports.views import ExportViewSet
+from exports.services.download_ticket import export_download_ticket_service
+
+
+DOWNLOAD_TICKET_CACHE = {
+    "default": {"BACKEND": "django.core.cache.backends.locmem.LocMemCache", "LOCATION": "export-view-download-tickets"}
+}
 
 
 class ExportViewSetTest(ExportsTestBase):
@@ -60,6 +67,36 @@ class ExportViewSetTest(ExportsTestBase):
         self.retry_view = self.view_set.as_view({"post": "retry"})
         self.retry_url = f"/exports/{self.failed_export.uuid}/retry/"
         self.logs_view = self.view_set.as_view({"get": "logs"})
+        self.download_view = self.view_set.as_view({"get": "download"})
+        self.download_ticket_view = self.view_set.as_view({"post": "download_ticket"})
+
+    @override_settings(CACHES=DOWNLOAD_TICKET_CACHE, EXPORT_DOWNLOAD_TICKET_TTL_SECONDS=60, DEBUG=False)
+    @mock.patch("exports.views.export.export_service.download")
+    def test_download_with_single_use_httponly_ticket(self, mock_download):
+        mock_download.return_value = StreamingHttpResponse([b"zip"])
+        export = self.target_export_to_retrieve
+        ticket_url = f"/exports/{export.uuid}/download-ticket/"
+        ticket_request = self.make_request(url=ticket_url, http_verb="post", request_user=self.exporter_user)
+
+        ticket_response = self.download_ticket_view(ticket_request, uuid=export.uuid)
+
+        cookie_name = export_download_ticket_service.cookie_name(export.uuid)
+        self.assertEqual(ticket_response.status_code, status.HTTP_201_CREATED)
+        self.assertTrue(ticket_response.cookies[cookie_name]["httponly"])
+        self.assertTrue(ticket_response.cookies[cookie_name]["secure"])
+        token = ticket_response.cookies[cookie_name].value
+
+        download_url = f"/exports/{export.uuid}/download/"
+        download_request = self.factory.get(download_url, HTTP_COOKIE=f"{cookie_name}={token}")
+        download_response = self.download_view(download_request, uuid=export.uuid)
+
+        self.assertEqual(download_response.status_code, status.HTTP_200_OK)
+        mock_download.assert_called_once_with(export=mock.ANY, range_header=None)
+        self.assertEqual(download_response.cookies[cookie_name]["max-age"], 0)
+
+        replay_request = self.factory.get(download_url, HTTP_COOKIE=f"{cookie_name}={token}")
+        replay_response = self.download_view(replay_request, uuid=export.uuid)
+        self.assertEqual(replay_response.status_code, status.HTTP_403_FORBIDDEN)
 
     def test_list_exports(self):
         list_url = reverse(viewname=self.viewname_list)

--- a/exports/views/export.py
+++ b/exports/views/export.py
@@ -1,6 +1,7 @@
 import json
 import logging
 
+from django.conf import settings
 from django.db import transaction
 from django.db.models import Q
 from django.db.models.expressions import Subquery, OuterRef
@@ -12,16 +13,25 @@ from requests.exceptions import RequestException
 from rest_framework import status
 from rest_framework.decorators import action
 from rest_framework.exceptions import ValidationError
+from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
 
 from admin_cohort.tools import join_qs
 from admin_cohort.tools.cache import cache_response
 from admin_cohort.tools.request_log_mixin import RequestLogMixin
 from admin_cohort.types import JobStatus
-from exports.exceptions import FilesNoLongerAvailable, BadRequestError, StorageProviderException
+from exports.exceptions import (
+    BadRequestError,
+    DownloadTicketUnavailable,
+    FilesNoLongerAvailable,
+    InvalidDownloadTicket,
+    InvalidRangeError,
+    StorageProviderException,
+)
 from exports.models import Export, ExportTable
 from exports.permissions import ExportPermission, RetryExportPermission, ExportLogsPermission
 from exports.serializers import ExportSerializer, ExportsListSerializer, ExportCreateSerializer
+from exports.services.download_ticket import export_download_ticket_service
 from exports.services.export import export_service
 from exports.views import ExportsBaseViewSet
 
@@ -83,6 +93,8 @@ class ExportViewSet(RequestLogMixin, ExportsBaseViewSet):
     )
 
     def get_permissions(self):
+        if self.action == self.download.__name__ and self._download_ticket_from_request():
+            return [AllowAny()]
         if self.action == self.retry.__name__ or self.action == self.relaunch.__name__:
             return [RetryExportPermission()]
         if self.action == self.logs.__name__:
@@ -134,12 +146,58 @@ class ExportViewSet(RequestLogMixin, ExportsBaseViewSet):
     @extend_schema(responses={(status.HTTP_200_OK, "application/zip"): OpenApiTypes.BINARY})
     @action(detail=True, methods=["get"], url_path="download")
     def download(self, request, *args, **kwargs):
+        export_uuid = kwargs[self.lookup_field]
+        ticket = self._download_ticket_from_request()
         try:
-            return export_service.download(export=self.get_object())
+            if ticket:
+                export_download_ticket_service.consume(token=ticket, expected_export_uuid=export_uuid)
+                export = Export.objects.get(pk=export_uuid)
+            else:
+                export = self.get_object()
+            response = export_service.download(export=export, range_header=request.headers.get("Range"))
+            if ticket:
+                response.delete_cookie(export_download_ticket_service.cookie_name(export_uuid), path="/", samesite="Strict")
+            return response
         except (BadRequestError, FilesNoLongerAvailable) as e:
             return Response(data=f"Error downloading files: {e}", status=status.HTTP_400_BAD_REQUEST)
+        except InvalidDownloadTicket as e:
+            return Response(data=str(e), status=status.HTTP_403_FORBIDDEN)
+        except InvalidRangeError as e:
+            response = Response(data=str(e), status=status.HTTP_416_REQUESTED_RANGE_NOT_SATISFIABLE)
+            response["Content-Range"] = "bytes */*"
+            return response
         except StorageProviderException as e:
             return Response(data=f"Storage provider error: {e}", status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+
+    @extend_schema(responses={status.HTTP_201_CREATED: OpenApiTypes.OBJECT})
+    @action(detail=True, methods=["post"], url_path="download-ticket")
+    def download_ticket(self, request, *args, **kwargs):
+        export = self.get_object()
+        try:
+            ticket = export_download_ticket_service.issue(export_uuid=export.uuid, user_id=request.user.pk)
+        except DownloadTicketUnavailable as e:
+            return Response(data=str(e), status=status.HTTP_503_SERVICE_UNAVAILABLE)
+
+        response = Response(
+            data={"expires_in": export_download_ticket_service.ttl_seconds},
+            status=status.HTTP_201_CREATED,
+        )
+        response.set_cookie(
+            export_download_ticket_service.cookie_name(export.uuid),
+            ticket,
+            max_age=export_download_ticket_service.ttl_seconds,
+            httponly=True,
+            secure=not settings.DEBUG,
+            samesite="Strict",
+            path="/",
+        )
+        return response
+
+    def _download_ticket_from_request(self):
+        export_uuid = self.kwargs.get(self.lookup_field)
+        if export_uuid is None:
+            return None
+        return self.request.COOKIES.get(export_download_ticket_service.cookie_name(export_uuid))
 
     @extend_schema(responses={status.HTTP_200_OK: OpenApiTypes.STR})
     @action(detail=True, methods=["post"], url_path="retry")


### PR DESCRIPTION
## Constat confirmé en production

Le bug est reproduit avec curl : plusieurs requêtes réparties sur les pods Django s'arrêtent entre 1,089 et 1,103 Go pour un ZIP de 1,752 Go. Axios et les Blobs ne sont donc pas la cause racine.

## Correctif de résilience

- ticket court, opaque et HttpOnly pour permettre une navigation navigateur autorisée ;
- support HTTP Range et réponses 206 pour reprendre un téléchargement interrompu ;
- en-têtes Accept-Ranges, Content-Range, Content-Length et X-Accel-Buffering ;
- upstream Nginx forcés sur 127.0.0.1 ;
- tests unitaires du ticket, du Range et du flux.

Le support Range limite l'impact d'une coupure, mais la suppression de la coupure elle-même relève de la chaîne proxy/Ingress.

## Validation

- Ruff check : OK ;
- compilation Python : OK ;
- git diff --check : OK ;
- CI ruff format : deux fichiers de tests à reformater ; correction en attente d'approbation.