### PR TITLE
fix(nginx): upstreams en 127.0.0.1 au lieu de localhost

### DIFF
--- a/.conf/nginx.conf
+++ b/.conf/nginx.conf
@@ -11,11 +11,11 @@ events {
 http {
 
     upstream backend {
-        server localhost:8000;
+        server 127.0.0.1:8000;
     }
 
     upstream channels-backend {
-        server localhost:8005;
+        server 127.0.0.1:8005;
     }
 
 	##


### PR DESCRIPTION
## Objectif
Le nginx du pod back logge un `connection refused` sur `[::1]:8000` à chaque requête : `localhost` est résolu en `::1` en premier, or gunicorn n'écoute qu'en IPv4.

## Changements réalisés
Upstreams `backend` et `channels-backend` pointés sur `127.0.0.1` au lieu de `localhost`.

## Impacts
Back (nginx).

## Tests réalisés
Manuel.

## Risques
Aucun.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved service connectivity by using explicit loopback addresses for backend connections.
  * Increased reliability of standard HTTP and channel-based backend routing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->