### PR TITLE
fix(ci): decouple Sonar quality gate from image publishing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,10 +50,10 @@ jobs:
         run: uv python install 3.13
 
       - name: Ruff (lint)
-        run: uv tool run ruff@0.15.22 check .
+        run: uv tool run --no-build ruff@0.15.22 check .
 
       - name: Ruff (format)
-        run: uv tool run ruff@0.15.22 format --check .
+        run: uv tool run --no-build ruff@0.15.22 format --check .
 
   safety:
     needs: [pr-target-guard]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -218,6 +218,7 @@ jobs:
           path: coverage.xml
 
   sonar:
+    continue-on-error: true  # TODO: remove when Sonar issues are handled
     if: |
       github.event_name == 'pull_request'
       || (

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -218,7 +218,6 @@ jobs:
           path: coverage.xml
 
   sonar:
-    continue-on-error: true  # TODO: remove when Sonar issues are handled
     if: |
       github.event_name == 'pull_request'
       || (

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.projectKey=aphp_Cohort360-Back-end
 sonar.organization=aphp
-sonar.qualitygate.wait=true
+sonar.qualitygate.wait=false
 sonar.python.version=3
 sonar.python.coverage.reportPaths=./coverage.xml
 sonar.issue.ignore.multicriteria=todos,comments


### PR DESCRIPTION
## Objectif

Permettre la publication de l'image Docker backend `develop` lorsqu'un Quality Gate Sonar est rouge, sans masquer les erreurs techniques du scanner Sonar.

## Changements

- configure `sonar.qualitygate.wait=false` pour ne plus faire échouer le workflow sur le seul résultat du Quality Gate ;
- conserve l'analyse et le résultat du Quality Gate dans SonarCloud ;
- ajoute `--no-build` aux commandes Ruff afin de corriger les deux vulnérabilités `githubactions:S8541` remontées par Sonar.

## Comportement attendu

- une erreur technique Sonar — authentification, configuration, réseau ou scanner — reste bloquante ;
- un Quality Gate Sonar rouge reste visible, mais ne bloque plus le publish Docker ;
- Ruff, MyPy, Bandit, Deptry et les tests Django restent bloquants ;
- après un push validé sur `develop`, l'image `aphpid/cohort360-backend:develop` est publiée automatiquement.

## Validation

- Ruff lint : succès ;
- Ruff format : succès ;
- Commitlint, Safety, Bandit et Deptry : succès.