### PR TITLE
chore(deps): cap django to <5.1 (PostgreSQL 12 compat)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,8 @@ dependencies = [
     "django-redis>=5.4.0",
     "django-safedelete>=1.4.0",
     "django-websocket-redis>=0.6.0",
-    "django==5.0.14",
+    # Rester sous Django 5.1 : Django 5.1 exige PostgreSQL >= 13, notre base est en PostgreSQL 12.
+    "django>=5.0.14,<5.1",
     "djangorestframework>=3.15.2",
     "drf-api-tracking>=1.8.4",
     "drf-extensions>=0.7.1",

--- a/uv.lock
+++ b/uv.lock
@@ -467,7 +467,7 @@ requires-dist = [
     { name = "channels-redis", specifier = ">=4.2.1" },
     { name = "coverage", specifier = ">=7.6.9" },
     { name = "daphne", specifier = ">=4.1.2" },
-    { name = "django", specifier = "==5.0.14" },
+    { name = "django", specifier = ">=5.0.14,<5.1" },
     { name = "django-celery-beat", specifier = ">=2.7.0" },
     { name = "django-cors-headers", specifier = ">=4.6.0" },
     { name = "django-environ", specifier = ">=0.11.2" },


### PR DESCRIPTION
## Contexte

La montée de Django `5.0.14` → `5.1.15` (PR #571) a dû être revertée (PR #580) parce que **Django 5.1 impose PostgreSQL >= 13** ([release notes](https://docs.djangoproject.com/en/5.1/releases/5.1/#dropped-support-for-postgresql-12)), or notre base de production tourne encore sur PostgreSQL 12.

Sans borne sur `pyproject.toml`, dependabot reproposera systématiquement la même bump 5.1.x qui repassera dans la même impasse.

## Changement

- `pyproject.toml` : `django==5.0.14` → `django>=5.0.14,<5.1` avec commentaire justifiant la borne.
- `uv.lock` : régénéré (spécificateur uniquement — la version résolue reste `5.0.14`).

## Levée du pin

À faire lorsque la base sera migrée en PostgreSQL >= 13.