### PR TITLE
chore(deps): cap django to <5.1 (PostgreSQL 12 compat)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,8 @@ dependencies = [
     "django-redis>=5.4.0",
     "django-safedelete>=1.4.0",
     "django-websocket-redis>=0.6.0",
-    "django==5.0.14",
+    # Rester sous Django 5.1 : Django 5.1 exige PostgreSQL >= 13, notre base est en PostgreSQL 12.
+    "django>=5.0.14,<5.1",
     "djangorestframework>=3.15.2",
     "drf-api-tracking>=1.8.4",
     "drf-extensions>=0.7.1",

--- a/uv.lock
+++ b/uv.lock
@@ -467,7 +467,7 @@ requires-dist = [
     { name = "channels-redis", specifier = ">=4.2.1" },
     { name = "coverage", specifier = ">=7.6.9" },
     { name = "daphne", specifier = ">=4.1.2" },
-    { name = "django", specifier = "==5.0.14" },
+    { name = "django", specifier = ">=5.0.14,<5.1" },
     { name = "django-celery-beat", specifier = ">=2.7.0" },
     { name = "django-cors-headers", specifier = ">=4.6.0" },
     { name = "django-environ", specifier = ">=0.11.2" },


### PR DESCRIPTION
## Objectif
Dependabot a bumpé Django de 5.0.14 à 5.2.16 (#582), incompatible avec notre base en PostgreSQL 12 : Django 5.1 exige PG >= 13 et Django 5.2 exige PG >= 14. Le bump a été reverté, mais la contrainte du manifeste était un pin exact, que Dependabot réécrit, donc rien n'empêche la PR de revenir.

## Changements réalisés
Passage de `django==5.0.14` à `django>=5.0.14,<5.1` dans `pyproject.toml`, avec la justification en commentaire, et régénération du `uv.lock`.

## Impacts
Back : aucun changement de version installée, Django reste résolu en 5.0.14. La borne haute vaut jusqu'à la montée de version de PostgreSQL, suivie côté infra.

## Tests réalisés
Résolution vérifiée avec `uv lock`.

## Risques
Django 5.0 n'est plus maintenu en amont depuis avril 2025, les alertes de sécurité Django resteront donc sans correctif applicable tant que la base n'est pas montée en PG 14.
